### PR TITLE
feat(report): add whyMatched explanation per Top 3 role (closes #18)

### DIFF
--- a/src/components/ReportRoles.tsx
+++ b/src/components/ReportRoles.tsx
@@ -61,6 +61,28 @@ export default function ReportRoles({ data }: { data: RolesData }) {
               </div>
             )}
 
+            <div
+              className={`mt-3 rounded-lg border p-3 text-sm ${
+                m.whyMatched.zeroHit
+                  ? "border-rose-200 bg-rose-50/50"
+                  : m.whyMatched.educationPenalty ||
+                      m.whyMatched.lowConfidence ||
+                      (m.whyMatched.industryFit && !m.whyMatched.industryFit.match)
+                    ? "border-amber-200 bg-amber-50/50"
+                    : "border-slate-200 bg-slate-50/60"
+              }`}
+            >
+              <p className="text-xs font-bold text-slate-700 mb-1.5">为什么是你？</p>
+              <ul className="space-y-1 text-slate-700 leading-relaxed">
+                {m.whyMatched.reasoning.map((line, i) => (
+                  <li key={i} className="flex gap-1.5">
+                    <span className="text-slate-400">·</span>
+                    <span>{line}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
             {m.role.top_industries && m.role.top_industries.length > 0 && (
               <p className="text-xs text-slate-500 mt-2">
                 Top 行业：

--- a/src/lib/matching.ts
+++ b/src/lib/matching.ts
@@ -4,6 +4,24 @@ import { Role, Skill } from "./fetchAgentHunt";
 import { UserInput } from "./encoding";
 import { TRACKS } from "@/data/tracks";
 
+export interface WhyMatched {
+  hitRequired: string[]; // canonical names of required skills hit
+  hitPreferred: string[]; // canonical names of preferred skills hit
+  totalRequired: number;
+  totalPreferred: number;
+  targetTrackBoost: { trackId: string; trackName: string } | null;
+  educationPenalty: { advancedPct: number; userEdu: string } | null;
+  lowConfidence: { skillCoverage: number } | null;
+  industryFit: {
+    userIndustriesCN: string[];
+    roleTopIndustriesCN: string[];
+    intersect: string[];
+    match: boolean;
+  } | null;
+  zeroHit: boolean;
+  reasoning: string[];
+}
+
 export interface RoleMatch {
   roleId: string;
   roleName: string;
@@ -11,7 +29,33 @@ export interface RoleMatch {
   matchedSkills: string[]; // canonical names
   missingSkills: { name: string; importance: number }[]; // missing required + preferred, sorted by count
   role: Role;
+  whyMatched: WhyMatched;
 }
+
+// 表单 industry 选项（中文）↔ roles-domestic.json top_industries（英文）双向映射
+const INDUSTRY_CN_TO_EN: Record<string, string> = {
+  互联网: "internet",
+  金融: "finance",
+  医疗: "healthcare",
+  制造: "manufacturing",
+  零售: "retail",
+  教育: "education",
+};
+
+const INDUSTRY_EN_TO_CN: Record<string, string> = {
+  internet: "互联网",
+  finance: "金融",
+  healthcare: "医疗",
+  manufacturing: "制造",
+  retail: "零售",
+  education: "教育",
+  automotive: "汽车",
+  consulting: "咨询",
+  energy: "能源",
+  government: "政府",
+  media: "媒体",
+  other: "其他",
+};
 
 // 预先构建一个 alias map：把用户输入的常见技能名映射到 skill_id
 // 简化版：同时支持 canonical name 完整匹配 + id 完整匹配 + 子串包含
@@ -69,12 +113,12 @@ function getSkillName(skillId: string, allSkills: Skill[]): string {
   return sk ? sk.canonical_name : skillId;
 }
 
-// 教育要求估算：如果角色 education 字段中 master + phd > 50%，认为要求"高学历"
-function roleRequiresAdvancedDegree(role: Role): boolean {
+// 角色 JD 中 master+phd 的占比；> 50% 视为"高学历要求"
+function roleAdvancedDegreePct(role: Role): number {
   const total = Object.values(role.education).reduce((a, b) => a + b, 0);
-  if (total === 0) return false;
+  if (total === 0) return 0;
   const advanced = (role.education.master || 0) + (role.education.phd || 0);
-  return advanced / total > 0.5;
+  return advanced / total;
 }
 
 const educationLevel: Record<string, number> = {
@@ -103,6 +147,13 @@ export function matchUserToRoles(
     if (track) track.roleIds.forEach((r) => targetRoleIds.add(r));
   }
 
+  const userIndustriesCN = (input.industry || []).filter(
+    (i) => i && i !== "其他" && i.trim(),
+  );
+  const userIndustriesEN = userIndustriesCN
+    .map((cn) => INDUSTRY_CN_TO_EN[cn])
+    .filter((v): v is string => Boolean(v));
+
   const matches: RoleMatch[] = roles
     // 排除 "其他"（other）这种聚合桶，避免推非典型角色
     .filter((r) => r.role_id !== "other")
@@ -126,23 +177,26 @@ export function matchUserToRoles(
       // 100%，把主线锚点角色（product_manager / operations）挤掉。
       const skillCoverage = requiredIds.length + preferredIds.length;
       const confidenceFactor = Math.min(1, skillCoverage / 5);
+      const isLowConfidence = skillCoverage < 5;
       score *= confidenceFactor;
 
       // 加成：用户指定 targetTrack 且角色匹配
-      if (targetRoleIds.has(role.role_id)) {
-        score *= 1.2;
-      }
+      const triggeringTrack = TRACKS.find(
+        (t) => targetTrackIds.includes(t.id) && t.roleIds.includes(role.role_id),
+      );
+      const isTargetTrackBoosted = Boolean(triggeringTrack);
+      if (isTargetTrackBoosted) score *= 1.2;
 
       // 惩罚：高学历要求但用户低学历
-      if (roleRequiresAdvancedDegree(role) && userEduLevel < 3) {
-        score *= 0.5;
-      }
+      const advancedPct = roleAdvancedDegreePct(role);
+      const isEducationPenalized = advancedPct > 0.5 && userEduLevel < 3;
+      if (isEducationPenalized) score *= 0.5;
 
       score = Math.min(100, Math.round(score));
 
-      const matchedSkills = [...matchedRequired, ...matchedPreferred].map((id) =>
-        getSkillName(id, allSkills),
-      );
+      const hitRequiredNames = matchedRequired.map((id) => getSkillName(id, allSkills));
+      const hitPreferredNames = matchedPreferred.map((id) => getSkillName(id, allSkills));
+      const matchedSkills = [...hitRequiredNames, ...hitPreferredNames];
 
       const missingRequired = role.required_skills
         .filter((s) => !userSkillIds.has(s.skill_id))
@@ -151,6 +205,101 @@ export function matchUserToRoles(
       // 按 count（即出现频次/重要性）降序
       missingRequired.sort((a, b) => b.importance - a.importance);
 
+      // 行业匹配：把用户中文行业映射成英文 keyword 后与 role.top_industries 求交集
+      const roleTopIndustriesEN = (role.top_industries || []).slice(0, 5).map((t) => t.industry);
+      const intersectEN = userIndustriesEN.filter((en) => roleTopIndustriesEN.includes(en));
+      const industryFit =
+        userIndustriesCN.length > 0 && roleTopIndustriesEN.length > 0
+          ? {
+              userIndustriesCN,
+              roleTopIndustriesCN: roleTopIndustriesEN.map(
+                (en) => INDUSTRY_EN_TO_CN[en] ?? en,
+              ),
+              intersect: intersectEN.map((en) => INDUSTRY_EN_TO_CN[en] ?? en),
+              match: intersectEN.length > 0,
+            }
+          : null;
+
+      const zeroHit = matchedRequired.length === 0 && matchedPreferred.length === 0;
+
+      const reasoning: string[] = [];
+      if (zeroHit) {
+        reasoning.push(
+          `0 项命中：你填的技能与「${role.role_name}」的 ${requiredIds.length} 项必备 / ${preferredIds.length} 项优选都没交集。出现在 Top 3 不是因为技能匹配，优先看下方 Gap 节列出的待补技能。`,
+        );
+      } else {
+        const segs: string[] = [];
+        if (hitRequiredNames.length > 0) {
+          const sample = hitRequiredNames.slice(0, 5).join("、");
+          const more = hitRequiredNames.length > 5 ? "…" : "";
+          segs.push(
+            `必备技能命中 ${hitRequiredNames.length}/${requiredIds.length}（${sample}${more}）`,
+          );
+        }
+        if (hitPreferredNames.length > 0) {
+          const sample = hitPreferredNames.slice(0, 5).join("、");
+          const more = hitPreferredNames.length > 5 ? "…" : "";
+          segs.push(
+            `优选技能命中 ${hitPreferredNames.length}/${preferredIds.length}（${sample}${more}）`,
+          );
+        }
+        reasoning.push(`你的技能与该角色硬要求重合：${segs.join("；")}。`);
+      }
+
+      if (isTargetTrackBoosted && triggeringTrack) {
+        reasoning.push(
+          `你选了「${triggeringTrack.name}」主线 → 该角色得分 ×1.2 加权，提升了在你 Top 3 里的排序。`,
+        );
+      }
+
+      if (isEducationPenalized) {
+        reasoning.push(
+          `该角色 ${Math.round(advancedPct * 100)}% JD 要求硕士及以上，你目前 ${input.education} → 匹配分 ×0.5 折半，不是首选。`,
+        );
+      }
+
+      if (isLowConfidence) {
+        reasoning.push(
+          `聚类样本稀（required + preferred 仅 ${skillCoverage} 项）→ 统计稳定性低，分数仅供参考。`,
+        );
+      }
+
+      if (industryFit) {
+        if (industryFit.match) {
+          reasoning.push(
+            `行业匹配：你的目标行业「${industryFit.intersect.join("、")}」出现在该角色 Top 行业里。`,
+          );
+        } else {
+          reasoning.push(
+            `行业偏移：你的目标行业「${industryFit.userIndustriesCN.join("、")}」不在该角色 Top 行业（${industryFit.roleTopIndustriesCN.slice(0, 3).join(" / ")}）→ 跨行可能需要适配。`,
+          );
+        }
+      }
+
+      if (zeroHit) {
+        reasoning.push(
+          `建议：先去补 Gap 节列的必备技能，或在路线 B 自己锁定行业 + 岗位重新诊断。`,
+        );
+      }
+
+      const whyMatched: WhyMatched = {
+        hitRequired: hitRequiredNames,
+        hitPreferred: hitPreferredNames,
+        totalRequired: requiredIds.length,
+        totalPreferred: preferredIds.length,
+        targetTrackBoost:
+          isTargetTrackBoosted && triggeringTrack
+            ? { trackId: triggeringTrack.id, trackName: triggeringTrack.name }
+            : null,
+        educationPenalty: isEducationPenalized
+          ? { advancedPct, userEdu: input.education }
+          : null,
+        lowConfidence: isLowConfidence ? { skillCoverage } : null,
+        industryFit,
+        zeroHit,
+        reasoning,
+      };
+
       return {
         roleId: role.role_id,
         roleName: role.role_name,
@@ -158,6 +307,7 @@ export function matchUserToRoles(
         matchedSkills,
         missingSkills: missingRequired.slice(0, 8),
         role,
+        whyMatched,
       };
     });
 


### PR DESCRIPTION
## Summary

实现 #18 报告可解释性 — 为每个 Top 3 角色暴露推理链 `whyMatched`，让用户看清"为什么是这个角色"。

业务试用最尖锐的痛点：

> "他给我推荐了 AI 销售和 AI 商务这个岗位，在我看来就有一点点莫名其妙。"
> "他不是按照我自己的所在的行业和我自己的背景去做分析的，而只是我随便勾选了几个选项。"

本 PR 通过把匹配算法里**已经在用、但没暴露出来**的因子（命中骨架 / 主线加权 / 学历折扣 / 置信度 / 行业匹配）拼成中文叙事，让推荐结果不再是黑盒。

## Changes

- `src/lib/matching.ts`
  - 新增 `WhyMatched` interface（命中清单 + 因子布尔标记 + reasoning 数组）
  - 新增中英 industry 双向 alias（用户填的中文 ↔ roles-domestic.json 的英文 keyword）
  - 把原本 inline 的因子（boost / 学历折扣 / 置信度）提取成显式布尔，喂进 reasoning
  - `roleRequiresAdvancedDegree` 改名为 `roleAdvancedDegreePct`，暴露具体百分比
  - reasoning 按因子编排：基础命中 → 加权 → 折扣 → 置信度 → 行业 → fallback 建议
- `src/components/ReportRoles.tsx`
  - 在每个角色卡片新增"为什么是你？"区块
  - 三段配色：rose（0 命中）/ amber（学历折扣 / 低置信度 / 行业偏移）/ slate（正常）

## Test plan

实机三个场景跑通（dev server 上）：

- [x] **Happy path**：互联网 PM + 5 项技能 + targetTrack A + industry 互联网 → 三角色都正确显示命中数 + 行业匹配，第二角色显示主线 ×1.2 加权
- [x] **行业偏移**：教培背景 + industry 教育 → 三角色都标"行业偏移：你的目标行业「教育」不在该角色 Top 行业（互联网 / 制造 / 汽车）→ 跨行可能需要适配"，EN→CN 翻译生效
- [x] **Fallback (0 命中)**：剪映/Premiere 背景 → 三角色都诚实说"0 项命中：你填的技能与「X」的 N 项必备 / M 项优选都没交集"，并给"建议：先去补 Gap 节列的必备技能，或在路线 B 自己锁定行业 + 岗位重新诊断"
- [x] lint + tsc + build 全通过

## Acceptance criteria (from #18)

- [x] 每个推荐角色卡片都有可见的"为什么是你"解释区
- [x] 解释不是模板填空，要有完整推理链 — 因子驱动，每条都基于实际算法状态
- [x] fallback 场景的解释诚实，与 ReportFallbackNotice 信息一致 — 0 命中明确声明，不伪造命中
- [x] 移动端展示不破版 — 卡片为既有结构内的子段，沿用现有 padding

🤖 Generated with [Claude Code](https://claude.com/claude-code)