### PR TITLE
feat(ui): surface track contents on homepage + diagnose form (closes #20)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import TrackOverview from "@/components/TrackOverview";
 
 const HIGHLIGHTS = [
   { num: "2,370", label: "条真实 JD" },
@@ -63,6 +64,19 @@ export default function Home() {
               <p className="text-xs text-slate-500 mt-1">{h.label}</p>
             </div>
           ))}
+        </div>
+      </section>
+
+      {/* 4 主线总览 */}
+      <section className="px-4 pb-12 sm:pb-16">
+        <div className="max-w-6xl mx-auto">
+          <h2 className="text-2xl md:text-3xl font-black text-slate-900 mb-2 text-center">
+            4 条 AI 转型主线
+          </h2>
+          <p className="text-sm text-slate-500 mb-8 text-center max-w-2xl mx-auto">
+            非程序员转 AI 的 4 个可达方向。诊断会根据你的技能与目标，把你匹配到最合适的那条。
+          </p>
+          <TrackOverview />
         </div>
       </section>
 

--- a/src/components/DiagnosisForm.tsx
+++ b/src/components/DiagnosisForm.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { FORM_FIELDS, STEP_TITLES, FormField } from "@/data/form-fields";
 import { encodeInput, UserInput } from "@/lib/encoding";
 import { track } from "@/lib/track";
+import TrackOverview from "@/components/TrackOverview";
 
 type FormState = Record<string, string | string[] | number>;
 
@@ -235,6 +236,17 @@ function FieldRender({
     return (
       <div>
         {label}
+        {field.id === "targetTrack" && (
+          <details className="mt-2 group">
+            <summary className="text-xs text-blue-600 hover:text-blue-700 cursor-pointer select-none py-1 list-none flex items-center gap-1">
+              <span className="transition-transform group-open:rotate-90">▸</span>
+              <span className="hover:underline">4 条主线分别是什么？点开看关键技能、适合人群、JD 数量</span>
+            </summary>
+            <div className="mt-3 mb-1">
+              <TrackOverview />
+            </div>
+          </details>
+        )}
         <div className="flex flex-wrap gap-2 mt-2">
           {field.options?.map((opt) => {
             const on = selected.includes(opt);

--- a/src/components/TrackOverview.tsx
+++ b/src/components/TrackOverview.tsx
@@ -1,0 +1,54 @@
+import { TRACKS } from "@/data/tracks";
+
+export default function TrackOverview() {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+      {TRACKS.map((t) => (
+        <div
+          key={t.id}
+          className="bg-white border border-blue-100 rounded-xl p-4 shadow-sm flex flex-col"
+        >
+          <div className="mb-2">
+            <h3 className="font-bold text-slate-900 leading-tight">
+              <span className="text-blue-600 font-mono mr-1">{t.id} ·</span>
+              {t.name}
+            </h3>
+            <p className="text-[11px] font-mono text-slate-400 mt-0.5">{t.nameEn}</p>
+          </div>
+
+          <p className="text-xs text-slate-500 mb-3">
+            {t.jdCount} JD · 中位 {(t.medianSalary / 1000).toFixed(1)}K/月
+          </p>
+
+          <div className="mb-2.5">
+            <p className="text-[11px] text-slate-500 mb-1">适合：</p>
+            <div className="flex flex-wrap gap-1">
+              {t.targetUsers.map((u) => (
+                <span
+                  key={u}
+                  className="text-[11px] bg-slate-50 text-slate-700 px-1.5 py-0.5 rounded border border-slate-200"
+                >
+                  {u}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <p className="text-[11px] text-slate-500 mb-1">关键技能：</p>
+            <div className="flex flex-wrap gap-1">
+              {t.keySkills.map((s) => (
+                <span
+                  key={s}
+                  className="text-[11px] bg-blue-50 text-blue-700 px-1.5 py-0.5 rounded border border-blue-200"
+                >
+                  {s}
+                </span>
+              ))}
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

实现 #20 主线分支透明化 — 把 TRACKS 数据里已有但没展示的字段（targetUsers / keySkills / jdCount / medianSalary）做成 <TrackOverview> 组件。

业务原话：

> "这四个主线的东西里面具体包括了哪些分支和细节呢？"

业务在选 targetTrack 时是盲选，因为前端只显示了主线名字。本 PR 让"这条主线包含什么"的信息在两处可见。

## Changes

- 新增 `src/components/TrackOverview.tsx` — 4 张主线卡片组件，每张展示 ID + 中英文名 + JD 数 + 薪资中位数 + 适合人群 chips + 关键技能 chips。响应式 1/2/4 列网格。
- `src/app/page.tsx` — 在 hero 与卖点之间加 "4 条 AI 转型主线" section，复用 TrackOverview。
- `src/components/DiagnosisForm.tsx` — Step 2 的 targetTrack 字段上方加 `<details>` 折叠面板，summary 写 "4 条主线分别是什么？点开看关键技能、适合人群、JD 数量"，点开里面是 TrackOverview。默认折叠避免占屏。

## Test plan

- [x] 首页 4 张卡片齐全（A/B/C/D），每张含 id + 中英文名 + JD 数 + 中位薪资 + 适合人群 + 关键技能
- [x] 表单 step 2 的 details panel 默认折叠，summary 正确显示
- [x] 点开 panel 后 4 张卡片都渲染（DOM 中 4 个 h3 命中 A·/B·/C·/D·）
- [x] lint + tsc + build 全通过
- [x] 移动端 1 列、≥640px 2 列、≥1024px 4 列 — 通过 Tailwind 默认断点保证

## Acceptance criteria (from #20)

- [x] 用户在选主线时能看到该主线包含哪些角色（targetUsers + keySkills 透明展示）
- [x] 移动端折叠展开正常 — 用 native `<details>`，零 JS，跨浏览器稳定
- [x] 5 主线（A/B/C/D/E）都覆盖 — 当前只覆盖 A/B/C/D（TRACKS 数据现状）；E 主线由 #17 单独引入，TrackOverview 直接 iterate TRACKS，#17 合并后 E 自动出现，无需改本组件

## 与 #17 的协调

按 #20 issue body 描述："与 #17 协调（E 主线加完后再做 E 的展开）"。本 PR 已将 TrackOverview 写为完全数据驱动，TRACKS 数组里多一条 E 它就自动多一张卡片，#17 落地无需回改本组件。

🤖 Generated with [Claude Code](https://claude.com/claude-code)