### PR TITLE
feat: route B · target Gap diagnosis end-to-end (closes #15)

### DIFF
--- a/src/app/diagnose-target/page.tsx
+++ b/src/app/diagnose-target/page.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+import DiagnosisFormB from "@/components/DiagnosisFormB";
+
+export default function DiagnoseTargetPage() {
+  return (
+    <main className="flex-1 px-4 py-12 md:py-16">
+      <div className="max-w-2xl mx-auto mb-8">
+        <Link
+          href="/"
+          className="text-sm text-slate-500 hover:text-blue-600 transition-colors"
+        >
+          ← 返回首页
+        </Link>
+        <h1 className="text-3xl md:text-4xl font-black text-slate-900 mt-3 mb-1">
+          目标 Gap 诊断
+        </h1>
+        <p className="text-sm text-slate-500">
+          已经有目标岗位 + 行业？选好后，我们围绕这个目标算匹配率 + 缺什么。
+        </p>
+      </div>
+      <DiagnosisFormB />
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -46,15 +46,29 @@ export default function Home() {
           运营 / 设计 / HR / 营销 / 咨询 / 传统行业转 AI · 不卖课不催单
         </p>
 
-        <Link
-          href="/diagnose"
-          className="inline-block bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white font-bold text-base sm:text-lg px-8 sm:px-10 py-4 rounded-full shadow-lg shadow-blue-600/20 transition-all hover:shadow-xl hover:-translate-y-0.5"
-        >
-          免费做一次诊断 →
-        </Link>
+        <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 items-stretch sm:items-center">
+          <Link
+            href="/diagnose"
+            className="inline-block bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white font-bold text-base sm:text-lg px-8 sm:px-10 py-4 rounded-full shadow-lg shadow-blue-600/20 transition-all hover:shadow-xl hover:-translate-y-0.5"
+          >
+            帮我定位 →
+          </Link>
+          <Link
+            href="/diagnose-target"
+            className="inline-block bg-white border-2 border-blue-600 text-blue-700 hover:bg-blue-50 active:bg-blue-100 font-bold text-base sm:text-lg px-8 sm:px-10 py-4 rounded-full transition-all"
+          >
+            我有目标，诊断匹配度 →
+          </Link>
+        </div>
         <p className="text-xs text-slate-400 mt-3">
           永久免费 · 无需注册 · 10 分钟出报告
         </p>
+        <div className="mt-4 max-w-xl text-xs text-slate-500 leading-relaxed">
+          <p>
+            <span className="font-bold text-blue-700">路线 A 帮我定位</span>：基于你的技能和背景推荐 Top 3 角色 ·{" "}
+            <span className="font-bold text-blue-700">路线 B 目标 Gap 诊断</span>：你锁定行业 + 岗位，算匹配率 + Gap
+          </p>
+        </div>
 
         {/* 数据锚点 */}
         <div className="mt-16 grid grid-cols-2 md:grid-cols-4 gap-4 md:gap-8 max-w-2xl w-full">

--- a/src/components/DiagnosisForm.tsx
+++ b/src/components/DiagnosisForm.tsx
@@ -2,10 +2,10 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import { FORM_FIELDS, STEP_TITLES, FormField } from "@/data/form-fields";
+import { FORM_FIELDS, STEP_TITLES } from "@/data/form-fields";
 import { encodeInput, UserInput } from "@/lib/encoding";
 import { track } from "@/lib/track";
-import TrackOverview from "@/components/TrackOverview";
+import { FormFieldRender } from "@/components/FormFieldRender";
 
 type FormState = Record<string, string | string[] | number>;
 
@@ -129,7 +129,7 @@ export default function DiagnosisForm() {
 
       <div className="bg-white border border-blue-100 rounded-2xl p-5 sm:p-6 md:p-8 shadow-sm space-y-6">
         {fieldsForStep.map((f) => (
-          <FieldRender
+          <FormFieldRender
             key={f.id}
             field={f}
             value={state[f.id]}
@@ -169,135 +169,3 @@ export default function DiagnosisForm() {
   );
 }
 
-function FieldRender({
-  field,
-  value,
-  onChange,
-  onToggleMulti,
-  customSkill,
-  setCustomSkill,
-  addCustomSkill,
-}: {
-  field: FormField;
-  value: string | string[] | number | undefined;
-  onChange: (v: string | string[] | number) => void;
-  onToggleMulti: (opt: string) => void;
-  customSkill: string;
-  setCustomSkill: (s: string) => void;
-  addCustomSkill: () => void;
-}) {
-  const label = (
-    <label className="block">
-      <span className="text-sm font-bold text-slate-900">
-        {field.label}
-        {field.required && <span className="text-red-500 ml-1">*</span>}
-      </span>
-      {field.hint && <span className="block text-xs text-slate-500 mt-0.5">{field.hint}</span>}
-    </label>
-  );
-
-  if (field.type === "text" || field.type === "number-range") {
-    return (
-      <div>
-        {label}
-        <input
-          type="text"
-          value={(value as string) || ""}
-          onChange={(e) => onChange(e.target.value)}
-          placeholder={field.placeholder}
-          className="mt-2 w-full px-4 py-3 border border-slate-200 rounded-lg focus:outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-100 text-slate-900 text-base"
-        />
-      </div>
-    );
-  }
-
-  if (field.type === "select" || field.type === "single-select") {
-    return (
-      <div>
-        {label}
-        <select
-          value={(value as string) || ""}
-          onChange={(e) => onChange(e.target.value)}
-          className="mt-2 w-full px-4 py-3 border border-slate-200 rounded-lg focus:outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-100 text-slate-900 bg-white text-base"
-        >
-          <option value="">请选择</option>
-          {field.options?.map((opt) => (
-            <option key={opt} value={opt}>
-              {opt}
-            </option>
-          ))}
-        </select>
-      </div>
-    );
-  }
-
-  if (field.type === "multi-select" || field.type === "multi-select-custom") {
-    const selected = (value as string[]) || [];
-    return (
-      <div>
-        {label}
-        {field.id === "targetTrack" && (
-          <details className="mt-2 group">
-            <summary className="text-xs text-blue-600 hover:text-blue-700 cursor-pointer select-none py-1 list-none flex items-center gap-1">
-              <span className="transition-transform group-open:rotate-90">▸</span>
-              <span className="hover:underline">4 条主线分别是什么？点开看关键技能、适合人群、JD 数量</span>
-            </summary>
-            <div className="mt-3 mb-1">
-              <TrackOverview />
-            </div>
-          </details>
-        )}
-        <div className="flex flex-wrap gap-2 mt-2">
-          {field.options?.map((opt) => {
-            const on = selected.includes(opt);
-            return (
-              <button
-                key={opt}
-                type="button"
-                onClick={() => onToggleMulti(opt)}
-                className={`text-sm px-3.5 py-2 rounded-full border transition-colors ${
-                  on
-                    ? "bg-blue-600 text-white border-blue-600"
-                    : "bg-white text-slate-700 border-slate-200 hover:border-blue-400"
-                }`}
-              >
-                {opt}
-              </button>
-            );
-          })}
-        </div>
-
-        {field.type === "multi-select-custom" && (
-          <div className="mt-3 flex gap-2">
-            <input
-              type="text"
-              value={customSkill}
-              onChange={(e) => setCustomSkill(e.target.value)}
-              placeholder="自定义技能（如：飞书多维表格）"
-              className="flex-1 px-3 py-2.5 text-sm border border-slate-200 rounded-lg focus:outline-none focus:border-blue-500 text-base"
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  e.preventDefault();
-                  addCustomSkill();
-                }
-              }}
-            />
-            <button
-              type="button"
-              onClick={addCustomSkill}
-              className="text-sm bg-slate-100 hover:bg-slate-200 active:bg-slate-300 text-slate-700 px-4 py-2.5 rounded-lg shrink-0"
-            >
-              添加
-            </button>
-          </div>
-        )}
-
-        {field.type === "multi-select-custom" && selected.length > 0 && (
-          <p className="mt-2 text-xs text-slate-500">已选 {selected.length} 项</p>
-        )}
-      </div>
-    );
-  }
-
-  return null;
-}

--- a/src/components/DiagnosisFormB.tsx
+++ b/src/components/DiagnosisFormB.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { FORM_FIELDS } from "@/data/form-fields";
+import { encodeInput, UserInput } from "@/lib/encoding";
+import { track } from "@/lib/track";
+import { fetchRoles, Role } from "@/lib/fetchAgentHunt";
+import { FormFieldRender } from "@/components/FormFieldRender";
+
+type FormState = Record<string, string | string[] | number>;
+
+const INDUSTRY_OPTIONS = ["互联网", "金融", "医疗", "制造", "零售", "教育", "其他"];
+
+// 路线 B 三步：锁定目标 / 背景 + 技能 / 偏好
+const STEP_TITLES_B: Record<1 | 2 | 3, string> = {
+  1: "1 / 3 · 锁定你的目标",
+  2: "2 / 3 · 你的背景与技能",
+  3: "3 / 3 · 偏好（全部可选，可跳过）",
+};
+
+const STEP_2_FIELD_IDS = ["yearsExp", "education", "currentJob", "city", "skills"];
+const STEP_3_FIELD_IDS = ["motivation", "expectedSalary", "timeBudget"];
+
+export default function DiagnosisFormB() {
+  const router = useRouter();
+  const [step, setStep] = useState<1 | 2 | 3>(1);
+  const [state, setState] = useState<FormState>({
+    skills: [],
+    targetIndustry: "",
+    targetRoleId: "",
+  });
+  const [customSkill, setCustomSkill] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [roles, setRoles] = useState<Role[]>([]);
+  const [rolesLoading, setRolesLoading] = useState(true);
+  const startedAtRef = useRef<number>(0);
+
+  useEffect(() => {
+    startedAtRef.current = Date.now();
+    fetchRoles()
+      .then((rs) => setRoles(rs.filter((r) => r.role_id !== "other")))
+      .catch((e) => setError(`角色列表加载失败：${e instanceof Error ? e.message : String(e)}`))
+      .finally(() => setRolesLoading(false));
+  }, []);
+
+  function set(id: string, value: string | string[] | number) {
+    setState((s) => ({ ...s, [id]: value }));
+  }
+
+  function toggleMulti(id: string, opt: string) {
+    const cur = (state[id] as string[]) || [];
+    set(id, cur.includes(opt) ? cur.filter((x) => x !== opt) : [...cur, opt]);
+  }
+
+  function addCustomSkill() {
+    const t = customSkill.trim();
+    if (!t) return;
+    const cur = (state.skills as string[]) || [];
+    if (!cur.includes(t)) set("skills", [...cur, t]);
+    setCustomSkill("");
+  }
+
+  function next() {
+    setError(null);
+    if (step === 1) {
+      if (!state.targetIndustry) {
+        setError("请选择目标行业");
+        return;
+      }
+      if (!state.targetRoleId) {
+        setError("请选择目标岗位");
+        return;
+      }
+    }
+    if (step === 2) {
+      if (!state.yearsExp) {
+        setError("请填写工作年限");
+        return;
+      }
+      if (!state.education) {
+        setError("请填写学历");
+        return;
+      }
+      if (((state.skills as string[]) || []).length < 3) {
+        setError("请至少选择 3 项已掌握的技能");
+        return;
+      }
+    }
+    if (step < 3) {
+      setStep((step + 1) as 1 | 2 | 3);
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    } else {
+      submit();
+    }
+  }
+
+  function prev() {
+    setError(null);
+    if (step > 1) setStep((step - 1) as 1 | 2 | 3);
+  }
+
+  function submit() {
+    const targetIndustry = state.targetIndustry as string;
+    const input: UserInput = {
+      currentJob: (state.currentJob as string) || "",
+      yearsExp: (state.yearsExp as string) || "",
+      education: (state.education as string) || "",
+      city: (state.city as string) || undefined,
+      skills: (state.skills as string[]) || [],
+      targetTrack: [],
+      motivation: (state.motivation as string) || undefined,
+      industry: targetIndustry ? [targetIndustry] : undefined,
+      timeBudget: (state.timeBudget as string) || undefined,
+      route: "B",
+      targetRoleId: (state.targetRoleId as string) || undefined,
+    };
+    const sal = state.expectedSalary as string;
+    if (sal && typeof sal === "string") {
+      const m = sal.match(/(\d+)\s*[-到~]\s*(\d+)/);
+      if (m) {
+        input.expectedSalaryMin = parseInt(m[1], 10);
+        input.expectedSalaryMax = parseInt(m[2], 10);
+      }
+    }
+    const hash = encodeInput(input);
+    track("route_b_submit", {
+      duration_ms: Date.now() - startedAtRef.current,
+      target_industry: targetIndustry,
+      target_role_id: input.targetRoleId,
+      skills_count: input.skills.length,
+    });
+    router.push(`/result/${hash}`);
+  }
+
+  const fieldIdsForStep = step === 2 ? STEP_2_FIELD_IDS : step === 3 ? STEP_3_FIELD_IDS : [];
+  const fieldsForStep = fieldIdsForStep
+    .map((id) => FORM_FIELDS.find((f) => f.id === id))
+    .filter((f): f is NonNullable<typeof f> => Boolean(f));
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <div className="mb-8">
+        <div className="flex items-center justify-between mb-2">
+          <p className="text-sm font-mono tracking-wide text-blue-700">{STEP_TITLES_B[step]}</p>
+          <p className="text-xs text-slate-500">{step} / 3</p>
+        </div>
+        <div className="h-2 bg-slate-100 rounded-full overflow-hidden">
+          <div
+            className="h-full bg-gradient-to-r from-blue-500 to-blue-700 transition-all"
+            style={{ width: `${(step / 3) * 100}%` }}
+          />
+        </div>
+      </div>
+
+      <div className="bg-white border border-blue-100 rounded-2xl p-5 sm:p-6 md:p-8 shadow-sm space-y-6">
+        {step === 1 && (
+          <>
+            <div>
+              <p className="text-xs text-slate-500 mb-3 leading-relaxed">
+                你已经有明确的求职目标 → 我们围绕这个目标算匹配率 + Gap，不再给你推 Top 3。
+              </p>
+            </div>
+
+            <div>
+              <label className="block">
+                <span className="text-sm font-bold text-slate-900">
+                  目标行业<span className="text-red-500 ml-1">*</span>
+                </span>
+              </label>
+              <div className="flex flex-wrap gap-2 mt-2">
+                {INDUSTRY_OPTIONS.map((opt) => {
+                  const on = state.targetIndustry === opt;
+                  return (
+                    <button
+                      key={opt}
+                      type="button"
+                      onClick={() => set("targetIndustry", opt)}
+                      className={`text-sm px-3.5 py-2 rounded-full border transition-colors ${
+                        on
+                          ? "bg-blue-600 text-white border-blue-600"
+                          : "bg-white text-slate-700 border-slate-200 hover:border-blue-400"
+                      }`}
+                    >
+                      {opt}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div>
+              <label className="block">
+                <span className="text-sm font-bold text-slate-900">
+                  目标岗位<span className="text-red-500 ml-1">*</span>
+                </span>
+                <span className="block text-xs text-slate-500 mt-0.5">
+                  从 14 个真实 JD 聚类的角色中选 1 个
+                </span>
+              </label>
+              {rolesLoading ? (
+                <p className="mt-2 text-sm text-slate-500">加载岗位列表中…</p>
+              ) : (
+                <select
+                  value={(state.targetRoleId as string) || ""}
+                  onChange={(e) => set("targetRoleId", e.target.value)}
+                  className="mt-2 w-full px-4 py-3 border border-slate-200 rounded-lg focus:outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-100 text-slate-900 bg-white text-base"
+                >
+                  <option value="">请选择</option>
+                  {roles
+                    .slice()
+                    .sort((a, b) => b.job_count - a.job_count)
+                    .map((r) => (
+                      <option key={r.role_id} value={r.role_id}>
+                        {r.role_name}（{r.job_count} JD · 中位{" "}
+                        {(r.salary.median / 1000).toFixed(1)}K）
+                      </option>
+                    ))}
+                </select>
+              )}
+            </div>
+          </>
+        )}
+
+        {step !== 1 &&
+          fieldsForStep.map((f) => (
+            <FormFieldRender
+              key={f.id}
+              field={f}
+              value={state[f.id]}
+              onChange={(v) => set(f.id, v)}
+              onToggleMulti={(opt) => toggleMulti(f.id, opt)}
+              customSkill={customSkill}
+              setCustomSkill={setCustomSkill}
+              addCustomSkill={addCustomSkill}
+            />
+          ))}
+
+        {error && (
+          <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg p-3">
+            {error}
+          </p>
+        )}
+
+        <div className="flex items-center justify-between pt-4 border-t border-slate-100">
+          <button
+            type="button"
+            onClick={prev}
+            disabled={step === 1}
+            className="text-sm text-slate-500 hover:text-slate-900 disabled:opacity-30"
+          >
+            ← 上一步
+          </button>
+          <button
+            type="button"
+            onClick={next}
+            className="bg-blue-600 hover:bg-blue-700 text-white font-bold px-6 py-3 rounded-full transition-colors"
+          >
+            {step === 3 ? "生成 Gap 报告 →" : "下一步 →"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/FormFieldRender.tsx
+++ b/src/components/FormFieldRender.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { FormField } from "@/data/form-fields";
+import TrackOverview from "@/components/TrackOverview";
+
+export type FieldValue = string | string[] | number | undefined;
+
+export function FormFieldRender({
+  field,
+  value,
+  onChange,
+  onToggleMulti,
+  customSkill,
+  setCustomSkill,
+  addCustomSkill,
+}: {
+  field: FormField;
+  value: FieldValue;
+  onChange: (v: string | string[] | number) => void;
+  onToggleMulti: (opt: string) => void;
+  customSkill: string;
+  setCustomSkill: (s: string) => void;
+  addCustomSkill: () => void;
+}) {
+  const label = (
+    <label className="block">
+      <span className="text-sm font-bold text-slate-900">
+        {field.label}
+        {field.required && <span className="text-red-500 ml-1">*</span>}
+      </span>
+      {field.hint && <span className="block text-xs text-slate-500 mt-0.5">{field.hint}</span>}
+    </label>
+  );
+
+  if (field.type === "text" || field.type === "number-range") {
+    return (
+      <div>
+        {label}
+        <input
+          type="text"
+          value={(value as string) || ""}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={field.placeholder}
+          className="mt-2 w-full px-4 py-3 border border-slate-200 rounded-lg focus:outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-100 text-slate-900 text-base"
+        />
+      </div>
+    );
+  }
+
+  if (field.type === "select" || field.type === "single-select") {
+    return (
+      <div>
+        {label}
+        <select
+          value={(value as string) || ""}
+          onChange={(e) => onChange(e.target.value)}
+          className="mt-2 w-full px-4 py-3 border border-slate-200 rounded-lg focus:outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-100 text-slate-900 bg-white text-base"
+        >
+          <option value="">请选择</option>
+          {field.options?.map((opt) => (
+            <option key={opt} value={opt}>
+              {opt}
+            </option>
+          ))}
+        </select>
+      </div>
+    );
+  }
+
+  if (field.type === "multi-select" || field.type === "multi-select-custom") {
+    const selected = (value as string[]) || [];
+    return (
+      <div>
+        {label}
+        {field.id === "targetTrack" && (
+          <details className="mt-2 group">
+            <summary className="text-xs text-blue-600 hover:text-blue-700 cursor-pointer select-none py-1 list-none flex items-center gap-1">
+              <span className="transition-transform group-open:rotate-90">▸</span>
+              <span className="hover:underline">4 条主线分别是什么？点开看关键技能、适合人群、JD 数量</span>
+            </summary>
+            <div className="mt-3 mb-1">
+              <TrackOverview />
+            </div>
+          </details>
+        )}
+        <div className="flex flex-wrap gap-2 mt-2">
+          {field.options?.map((opt) => {
+            const on = selected.includes(opt);
+            return (
+              <button
+                key={opt}
+                type="button"
+                onClick={() => onToggleMulti(opt)}
+                className={`text-sm px-3.5 py-2 rounded-full border transition-colors ${
+                  on
+                    ? "bg-blue-600 text-white border-blue-600"
+                    : "bg-white text-slate-700 border-slate-200 hover:border-blue-400"
+                }`}
+              >
+                {opt}
+              </button>
+            );
+          })}
+        </div>
+
+        {field.type === "multi-select-custom" && (
+          <div className="mt-3 flex gap-2">
+            <input
+              type="text"
+              value={customSkill}
+              onChange={(e) => setCustomSkill(e.target.value)}
+              placeholder="自定义技能（如：飞书多维表格）"
+              className="flex-1 px-3 py-2.5 text-sm border border-slate-200 rounded-lg focus:outline-none focus:border-blue-500 text-base"
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  addCustomSkill();
+                }
+              }}
+            />
+            <button
+              type="button"
+              onClick={addCustomSkill}
+              className="text-sm bg-slate-100 hover:bg-slate-200 active:bg-slate-300 text-slate-700 px-4 py-2.5 rounded-lg shrink-0"
+            >
+              添加
+            </button>
+          </div>
+        )}
+
+        {field.type === "multi-select-custom" && selected.length > 0 && (
+          <p className="mt-2 text-xs text-slate-500">已选 {selected.length} 项</p>
+        )}
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/src/components/ReportCover.tsx
+++ b/src/components/ReportCover.tsx
@@ -28,46 +28,80 @@ export default function ReportCover({ data }: { data: CoverData }) {
         </div>
       </div>
 
-      {/* 4 主线匹配度横向 bar */}
-      <div className="mb-8">
-        <h3 className="text-sm font-bold text-slate-700 mb-3">你和 4 主线的匹配度</h3>
-        <div className="space-y-2">
-          {data.trackScores.map(({ track, score }) => (
-            <div key={track.id} className="flex items-center gap-2 sm:gap-3">
-              <span className="w-24 sm:w-32 md:w-40 text-xs sm:text-sm font-medium text-slate-700 shrink-0">
-                {track.id} · {track.name}
-              </span>
-              <div className="flex-1 bg-slate-100 rounded-full h-3 overflow-hidden">
-                <div
-                  className="h-full bg-gradient-to-r from-blue-500 to-blue-700"
-                  style={{ width: `${score}%` }}
-                />
-              </div>
-              <span className="w-10 text-right text-sm font-mono font-bold text-blue-700">
-                {score}%
-              </span>
+      {data.route === "A" ? (
+        <>
+          {/* 4 主线匹配度横向 bar */}
+          <div className="mb-8">
+            <h3 className="text-sm font-bold text-slate-700 mb-3">你和 4 主线的匹配度</h3>
+            <div className="space-y-2">
+              {data.trackScores.map(({ track, score }) => (
+                <div key={track.id} className="flex items-center gap-2 sm:gap-3">
+                  <span className="w-24 sm:w-32 md:w-40 text-xs sm:text-sm font-medium text-slate-700 shrink-0">
+                    {track.id} · {track.name}
+                  </span>
+                  <div className="flex-1 bg-slate-100 rounded-full h-3 overflow-hidden">
+                    <div
+                      className="h-full bg-gradient-to-r from-blue-500 to-blue-700"
+                      style={{ width: `${score}%` }}
+                    />
+                  </div>
+                  <span className="w-10 text-right text-sm font-mono font-bold text-blue-700">
+                    {score}%
+                  </span>
+                </div>
+              ))}
             </div>
-          ))}
-        </div>
-      </div>
+          </div>
 
-      {/* Top 3 角色 */}
-      <div>
-        <h3 className="text-sm font-bold text-slate-700 mb-3">你最匹配的 3 个角色</h3>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-          {data.topRoles.map((r, idx) => (
-            <div
-              key={r.roleName}
-              className="bg-blue-50 border border-blue-200 rounded-lg p-4"
-            >
-              <p className="text-xs text-blue-600 font-mono mb-1">#{idx + 1}</p>
-              <p className="font-bold text-slate-900 text-sm mb-1">{r.roleName}</p>
-              <p className="text-2xl font-black text-blue-700">{r.matchScore}%</p>
-              <p className="text-xs text-slate-500 mt-1">匹配度</p>
+          {/* Top 3 角色 */}
+          <div>
+            <h3 className="text-sm font-bold text-slate-700 mb-3">你最匹配的 3 个角色</h3>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+              {data.topRoles.map((r, idx) => (
+                <div
+                  key={r.roleName}
+                  className="bg-blue-50 border border-blue-200 rounded-lg p-4"
+                >
+                  <p className="text-xs text-blue-600 font-mono mb-1">#{idx + 1}</p>
+                  <p className="font-bold text-slate-900 text-sm mb-1">{r.roleName}</p>
+                  <p className="text-2xl font-black text-blue-700">{r.matchScore}%</p>
+                  <p className="text-xs text-slate-500 mt-1">匹配度</p>
+                </div>
+              ))}
             </div>
-          ))}
+          </div>
+        </>
+      ) : (
+        // 路线 B：单一锁定目标 + 匹配率
+        <div>
+          <h3 className="text-sm font-bold text-slate-700 mb-3">你锁定的目标</h3>
+          {data.lockedTarget && data.topRoles[0] ? (
+            <div className="bg-blue-50 border border-blue-200 rounded-xl p-5">
+              <p className="text-xs text-blue-600 font-mono mb-1">TARGET</p>
+              <div className="flex items-baseline justify-between flex-wrap gap-3">
+                <div>
+                  {data.lockedTarget.industry && (
+                    <p className="text-sm text-slate-600 mb-1">
+                      {data.lockedTarget.industry} 行业
+                    </p>
+                  )}
+                  <p className="text-xl sm:text-2xl font-black text-slate-900">
+                    {data.lockedTarget.roleName}
+                  </p>
+                </div>
+                <div className="text-right">
+                  <p className="text-4xl sm:text-5xl font-black text-blue-700">
+                    {data.topRoles[0].matchScore}%
+                  </p>
+                  <p className="text-xs text-slate-500 mt-1">综合匹配度</p>
+                </div>
+              </div>
+            </div>
+          ) : (
+            <p className="text-sm text-slate-500">未锁定目标，请回到 /diagnose-target 重新选择</p>
+          )}
         </div>
-      </div>
+      )}
     </section>
   );
 }

--- a/src/components/ReportRoles.tsx
+++ b/src/components/ReportRoles.tsx
@@ -3,10 +3,13 @@ import { RolesData } from "@/lib/reportGen";
 export default function ReportRoles({ data }: { data: RolesData }) {
   return (
     <section className="bg-white rounded-2xl shadow-sm border border-blue-100 p-5 sm:p-8">
-      <h2 className="text-2xl font-black text-slate-900 mb-2">第 2 节 · 市场全景</h2>
+      <h2 className="text-2xl font-black text-slate-900 mb-2">
+        {data.route === "B" ? "第 2 节 · 你的目标匹配度" : "第 2 节 · 市场全景"}
+      </h2>
       <p className="text-sm text-slate-500 mb-6">
-        基于国内 {data.totalJDs.toLocaleString()} 条真实 JD 聚类的 {data.totalRoles} 个 AI
-        角色中，与你最匹配的 Top 3。
+        {data.route === "B"
+          ? `基于国内 ${data.totalJDs.toLocaleString()} 条真实 JD 聚类，分析你锁定的目标角色的匹配情况。`
+          : `基于国内 ${data.totalJDs.toLocaleString()} 条真实 JD 聚类的 ${data.totalRoles} 个 AI 角色中，与你最匹配的 Top 3。`}
       </p>
 
       <div className="space-y-4">

--- a/src/lib/encoding.ts
+++ b/src/lib/encoding.ts
@@ -13,6 +13,10 @@ export interface UserInput {
   expectedSalaryMin?: number;
   expectedSalaryMax?: number;
   timeBudget?: string;
+  // 路线 A（默认）= 系统推荐 Top 3 角色；路线 B = 用户锁定行业 + 岗位，只诊断匹配率
+  route?: "A" | "B";
+  // 路线 B 必填：用户锁定的 14 角色之一的 role_id（如 "product_manager"）
+  targetRoleId?: string;
 }
 
 function toBase64Url(str: string): string {

--- a/src/lib/matching.ts
+++ b/src/lib/matching.ts
@@ -132,6 +132,7 @@ export function matchUserToRoles(
   input: UserInput,
   roles: Role[],
   allSkills: Skill[],
+  options: { lockedRoleId?: string } = {},
 ): RoleMatch[] {
   const userSkillIds = normalizeUserSkills(input.skills, allSkills);
   const userEduLevel = educationLevel[input.education] ?? 2;
@@ -155,8 +156,10 @@ export function matchUserToRoles(
     .filter((v): v is string => Boolean(v));
 
   const matches: RoleMatch[] = roles
-    // 排除 "其他"（other）这种聚合桶，避免推非典型角色
-    .filter((r) => r.role_id !== "other")
+    // 路线 B：仅算用户锁定的角色；路线 A：排除 "其他" 聚合桶
+    .filter((r) =>
+      options.lockedRoleId ? r.role_id === options.lockedRoleId : r.role_id !== "other",
+    )
     .map((role) => {
       const requiredIds = role.required_skills.map((s) => s.skill_id);
       const preferredIds = role.preferred_skills.map((s) => s.skill_id);

--- a/src/lib/reportGen.ts
+++ b/src/lib/reportGen.ts
@@ -11,16 +11,20 @@ export interface CoverData {
   yearsExp: string;
   education: string;
   city?: string;
-  trackScores: { track: Track; score: number }[]; // 4 主线匹配度
+  trackScores: { track: Track; score: number }[]; // 4 主线匹配度（路线 B 时为空）
   topRoles: { roleName: string; matchScore: number }[];
   reportId: string;
   generatedAt: string;
+  route: "A" | "B";
+  // 路线 B：用户锁定的目标
+  lockedTarget?: { industry?: string; roleName: string };
 }
 
 export interface RolesData {
   topMatches: RoleMatch[];
   totalRoles: number;
   totalJDs: number;
+  route: "A" | "B";
 }
 
 export interface SalaryData {
@@ -62,6 +66,7 @@ export interface MetaData {
   // 前端会在 Cover 上方显示一个提示，说明原因并建议下一步。
   isFallback: boolean;
   fallbackTrack?: Track | null;
+  route: "A" | "B";
 }
 
 export interface Report {
@@ -200,6 +205,12 @@ export function generateReport(
   skills: Skill[],
   reportId: string,
 ): Report {
+  const route: "A" | "B" = input.route === "B" ? "B" : "A";
+
+  if (route === "B") {
+    return generateRouteBReport(input, roles, skills, reportId);
+  }
+
   const allMatches = matchUserToRoles(input, roles, skills);
   // calcTrackScores 走全量匹配，否则 top 3 若不含 track 对应角色，4 主线会全 0
   const trackScores = calcTrackScores(allMatches);
@@ -254,11 +265,13 @@ export function generateReport(
       })),
       reportId,
       generatedAt,
+      route: "A",
     },
     roles: {
       topMatches,
       totalRoles: 14,
       totalJDs: JD_TOTAL,
+      route: "A",
     },
     salary: buildSalary(input, top),
     gap: buildGap(top),
@@ -271,6 +284,66 @@ export function generateReport(
       reportId,
       isFallback,
       fallbackTrack,
+      route: "A",
+    },
+  };
+}
+
+// 路线 B：用户锁定行业 + 岗位，仅诊断该锁定角色的匹配率
+function generateRouteBReport(
+  input: UserInput,
+  roles: Role[],
+  skills: Skill[],
+  reportId: string,
+): Report {
+  const lockedRoleId = input.targetRoleId || "";
+  const matches = matchUserToRoles(input, roles, skills, { lockedRoleId });
+  const top = matches[0];
+  const lockedTrack = TRACKS.find((t) => t.roleIds.includes(lockedRoleId)) || null;
+  const generatedAt = new Date().toISOString().slice(0, 10);
+  const lockedIndustry = (input.industry || []).find((i) => i && i !== "其他");
+
+  // 路线 B 不做兜底锚点切换 — 用户已锁，不替换。0 命中由 whyMatched 诚实告知。
+  const isFallback = false;
+
+  return {
+    cover: {
+      title: top
+        ? `你能不能上「${lockedIndustry ? lockedIndustry + " · " : ""}${top.roleName}」`
+        : "AI 求职目标 Gap 诊断",
+      currentJob: input.currentJob,
+      yearsExp: input.yearsExp,
+      education: input.education,
+      city: input.city,
+      trackScores: [],
+      topRoles: top
+        ? [{ roleName: top.roleName, matchScore: top.matchScore }]
+        : [],
+      reportId,
+      generatedAt,
+      route: "B",
+      lockedTarget: top
+        ? { industry: lockedIndustry, roleName: top.roleName }
+        : undefined,
+    },
+    roles: {
+      topMatches: matches,
+      totalRoles: 14,
+      totalJDs: JD_TOTAL,
+      route: "B",
+    },
+    salary: buildSalary(input, top),
+    gap: buildGap(top),
+    paths: { topTrack: lockedTrack },
+    actions: buildActions(input, lockedTrack),
+    meta: {
+      jdTotal: JD_TOTAL,
+      rolesTotal: 14,
+      generatedAt,
+      reportId,
+      isFallback,
+      fallbackTrack: null,
+      route: "B",
     },
   };
 }


### PR DESCRIPTION
## Summary

实现 #15 路线 B 端到端 — 用户锁定行业 + 岗位，报告围绕该目标算匹配率 + Gap，不再强推 Top 3。

业务原话：

> "那还不如就直接确定一个岗位，我明确想做 XX 行业的 YY 岗位，那么在这个基础上，我差的东西是什么、应聘上的概率是百分之多少。"

路线 A 和路线 B 现在并行。**路线 A 行为完全不变**（UserInput.route 默认 "A"，所有已分享的报告 URL 仍然解码到 Top 3 流程）。

## Architecture

```
/                         首页 双 CTA
├── /diagnose             路线 A · DiagnosisForm（不变）
└── /diagnose-target      路线 B · DiagnosisFormB（新）
                          ↓
                          /result/<hash>  ← 同一报告页，按 input.route 分支
```

UserInput 加 2 个可选字段：
- `route?: "A" | "B"` （默认 A，向后兼容）
- `targetRoleId?: string` （路线 B 必填，14 角色之一）

## Changes

**数据层：**
- `src/lib/encoding.ts` — UserInput 加 `route` + `targetRoleId`
- `src/lib/matching.ts` — `matchUserToRoles` 加 `options.lockedRoleId`，路线 B 时仅计算锁定角色
- `src/lib/reportGen.ts` — 抽出 `generateRouteBReport`：跳过 trackScores，topMatches 只含锁定角色，cover 显示 lockedTarget

**UI 层：**
- `src/components/ReportCover.tsx` — 按 `data.route` 分支渲染（A 显示 4 主线 + Top 3 / B 显示锁定目标卡）
- `src/components/ReportRoles.tsx` — 按 `data.route` 切节标题与描述（"市场全景 / Top 3" → "你的目标匹配度"）
- `src/components/DiagnosisFormB.tsx` — 新 3 步表单（锁定目标 / 背景+技能 / 偏好）
- `src/app/diagnose-target/page.tsx` — 新路由
- `src/app/page.tsx` — 首页加路线 B CTA + 简短说明
- `src/components/FormFieldRender.tsx` — **重构**：从 DiagnosisForm 抽出来的字段渲染 helper，路线 A/B 共用

**埋点：**
- 路线 B 提交触发 `route_b_submit` 事件（含 target_industry / target_role_id / skills_count）

## Test plan

实机验证（dev server）：

- [x] **路线 B 报告**：industry=互联网, role=product_manager, skills=[Python, Prompt Engineering, 数据分析, PRD 写作]
  - 标题 "你能不能上「互联网 · AI 产品经理」"
  - Cover 显示锁定目标卡片 + 17% 匹配度（不显示 4 主线）
  - 第 2 节 "你的目标匹配度"，只有 1 个角色卡
  - whyMatched: "必备技能命中 2/10（Data Analysis、Prompt Engineering）" + "行业匹配：互联网"
  - Gap / 路径 / Action 围绕 AI 产品经理
- [x] **路线 A 回归**：之前的 happy path URL 完全不变，4 主线 + Top 3 + "市场全景" 节标题都在
- [x] **首页双 CTA**：`/diagnose` 和 `/diagnose-target` 链接都在
- [x] **表单 B step 1**：7 个行业 chip + 14 角色 select（按 JD 数排序）
- [x] lint + tsc + build 全通过

## Acceptance criteria (from #15)

- [x] 首页能切换两条路线（双 CTA + 短说明）
- [x] 路线 B 完整跑通：行业/岗位选择器 → 表单 → 报告
- [x] 报告匹配率算法对用户透明 — 复用 #18 的 whyMatched，命中/缺漏说得清楚
- [x] 埋点区分 route_a_submit / route_b_submit
- [x] 路线 B 不展示 Top 3 推荐（不抢用户已确定的目标）

## 数据精度后续

依赖 LLM-X-Factorer/agent-hunt#9（行业 × 岗位二维切片）：
- 当前路线 B 的行业匹配仍走 #18 已有的 role.top_industries，是单维聚合；
- agent-hunt#9 落地后，"行业内 JD 数 / 行业内薪资中位数" 可以替换全市场聚合，进一步贴近用户的"达成概率" 诉求 — 那部分由 #19 接手。

🤖 Generated with [Claude Code](https://claude.com/claude-code)