### PR TITLE
feat(report): route A bottom CTA → route B with prefill (closes #21)

### DIFF
--- a/src/app/diagnose-target/page.tsx
+++ b/src/app/diagnose-target/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { Suspense } from "react";
 import DiagnosisFormB from "@/components/DiagnosisFormB";
 
 export default function DiagnoseTargetPage() {
@@ -18,7 +19,15 @@ export default function DiagnoseTargetPage() {
           已经有目标岗位 + 行业？选好后，我们围绕这个目标算匹配率 + 缺什么。
         </p>
       </div>
-      <DiagnosisFormB />
+      <Suspense
+        fallback={
+          <div className="max-w-2xl mx-auto text-center text-sm text-slate-500 py-12">
+            正在加载表单…
+          </div>
+        }
+      >
+        <DiagnosisFormB />
+      </Suspense>
     </main>
   );
 }

--- a/src/app/result/[hash]/ReportClient.tsx
+++ b/src/app/result/[hash]/ReportClient.tsx
@@ -148,6 +148,25 @@ export default function ReportClient({ hash }: { hash: string }) {
           <ReportPaths data={report.paths} />
           <ReportActions actions={report.actions} meta={report.meta} />
         </LockedSections>
+        {report.meta.route === "A" && (
+          <section className="bg-blue-50 border border-blue-200 rounded-2xl p-5 sm:p-8 text-center">
+            <h3 className="text-lg sm:text-xl font-bold text-slate-900 mb-2">
+              这 3 个推荐都不是你想要的？
+            </h3>
+            <p className="text-sm text-slate-600 mb-5 max-w-xl mx-auto leading-relaxed">
+              换个方式：你自己锁定行业 + 岗位，我们围绕你的目标算匹配率 + Gap，不再给推荐。已填字段会自动带过去，不用重填。
+            </p>
+            <Link
+              href={`/diagnose-target?from=${encodeURIComponent(hash)}`}
+              onClick={() =>
+                track("report_reject_top3_click", { report_id: report.meta.reportId })
+              }
+              className="inline-block bg-white border-2 border-blue-600 text-blue-700 hover:bg-blue-50 active:bg-blue-100 font-bold px-6 py-3 rounded-full transition-all"
+            >
+              切到目标 Gap 诊断 →
+            </Link>
+          </section>
+        )}
       </div>
 
       <footer className="border-t border-slate-200 px-4 py-6 text-center text-xs text-slate-500 bg-white">

--- a/src/components/DiagnosisFormB.tsx
+++ b/src/components/DiagnosisFormB.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { FORM_FIELDS } from "@/data/form-fields";
-import { encodeInput, UserInput } from "@/lib/encoding";
+import { decodeInput, encodeInput, UserInput } from "@/lib/encoding";
 import { track } from "@/lib/track";
 import { fetchRoles, Role } from "@/lib/fetchAgentHunt";
 import { FormFieldRender } from "@/components/FormFieldRender";
@@ -22,14 +22,37 @@ const STEP_TITLES_B: Record<1 | 2 | 3, string> = {
 const STEP_2_FIELD_IDS = ["yearsExp", "education", "currentJob", "city", "skills"];
 const STEP_3_FIELD_IDS = ["motivation", "expectedSalary", "timeBudget"];
 
+function buildInitialState(fromHash: string | null): FormState {
+  const base: FormState = { skills: [], targetIndustry: "", targetRoleId: "" };
+  if (!fromHash) return base;
+  try {
+    const prev = decodeInput(fromHash);
+    return {
+      ...base,
+      currentJob: prev.currentJob || "",
+      yearsExp: prev.yearsExp || "",
+      education: prev.education || "",
+      city: prev.city || "",
+      skills: prev.skills || [],
+      motivation: prev.motivation || "",
+      timeBudget: prev.timeBudget || "",
+      targetIndustry: (prev.industry && prev.industry[0]) || "",
+      expectedSalary:
+        prev.expectedSalaryMin && prev.expectedSalaryMax
+          ? `${prev.expectedSalaryMin}-${prev.expectedSalaryMax}`
+          : "",
+    };
+  } catch {
+    return base;
+  }
+}
+
 export default function DiagnosisFormB() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const fromHash = searchParams.get("from");
   const [step, setStep] = useState<1 | 2 | 3>(1);
-  const [state, setState] = useState<FormState>({
-    skills: [],
-    targetIndustry: "",
-    targetRoleId: "",
-  });
+  const [state, setState] = useState<FormState>(() => buildInitialState(fromHash));
   const [customSkill, setCustomSkill] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [roles, setRoles] = useState<Role[]>([]);


### PR DESCRIPTION
## Summary

实现 #21 报告兜底 — 路线 A 报告底部加 CTA "这 3 个推荐都不是你想要的？切到目标 Gap 诊断"，跳转到 /diagnose-target 时自动带上用户已填字段，避免重填。

业务原话：

> "如果我既不想做数据分析，也不想做 AI 商务，那那那接下来我要做的东西是什么呢？"

依赖 #15（已合）。

## Changes

- `src/app/result/[hash]/ReportClient.tsx` — LockedSections 之后增加 CTA section，仅在 `report.meta.route === "A"` 时渲染（路线 B 用户已锁定目标，不需要再切）
- `src/components/DiagnosisFormB.tsx`：
  - 用 `useSearchParams` 读 `?from=<hash>`，base64url 解码后预填 currentJob / yearsExp / education / city / skills / motivation / timeBudget / targetIndustry / expectedSalary
  - 预填挪到 `useState(() => buildInitialState(fromHash))` 初始化函数里，避免 React 19 `set-state-in-effect` 规则
- `src/app/diagnose-target/page.tsx` — `<Suspense>` 包裹 DiagnosisFormB（Next 16 要求 useSearchParams 的客户端组件外有 Suspense 边界）
- 埋点 `report_reject_top3_click` 在 CTA onClick 触发

## Test plan

- [x] 路线 A 报告底部 CTA 可见，文案 "这 3 个推荐都不是你想要的？" + "切到目标 Gap 诊断 →"
- [x] CTA href 正确指向 `/diagnose-target?from=<原 hash>`
- [x] 跳转后表单 step 1 的 targetIndustry 自动选中（用户原 industry 第一个）；其他字段在 step 2/3 切换时也会预填
- [x] 路线 B 报告**不**显示该 CTA（用户已锁定目标，无需再切）
- [x] 无效 hash 时静默忽略，让用户从空表单开始（fallback 容错）
- [x] lint + tsc + build 全通过
- [x] /diagnose-target 仍是 static prerender（Suspense 让 useSearchParams 不破坏静态生成）

## Acceptance criteria (from #21)

- [x] 报告底部 CTA 可见（移动端不被遮罩盖住）— 放在 LockedSections 之后，与遮罩同级渲染，不会被遮
- [x] 点击跳转到路线 B 入口，已填字段保留 — 通过 `?from=<hash>` 传递
- [x] 埋点正常上报 — `report_reject_top3_click` 在 onClick 中触发

🤖 Generated with [Claude Code](https://claude.com/claude-code)