### PR TITLE
feat: fresh-grad as first-class audience + double-route / double-audience lock decisions (closes #16, partial #17)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,13 @@
 
 ## Overview
 
-非程序员 AI 求职定位诊断。基于 [Agent Hunt](https://github.com/LLM-X-Factorer/agent-hunt) 的 2370+ JD 数据 + 14 国内角色聚类，把用户的技能/年限/学历匹配到 Top 3 角色并生成 7 节诊断报告。
+非程序员 AI 求职定位诊断。基于 [Agent Hunt](https://github.com/LLM-X-Factorer/agent-hunt) 的 2370+ JD 数据 + 14 国内角色聚类，生成 7 节诊断报告。
+
+**两条路线并行**：
+- **路线 A · 帮我定位**（`/diagnose`）：填技能 + 背景 → 系统推荐 Top 3 角色 + 4 主线分布 + Gap/路径/Action
+- **路线 B · 目标 Gap 诊断**（`/diagnose-target`）：用户锁定行业 + 岗位 → 仅算锁定角色匹配率 + Gap，不展示 Top 3
+
+**双一等受众**：社招用户 + 应届生 / 学生（含在读、应届无实习、应届有实习），表单分支 + 报告路径文案做应届/社招差异化。
 
 **定位：永久免费 + 加微信漏斗**。本 app 不做产品内付费；商业化走产品外部渠道（1V1 / 社群 / 课程），与本仓库解耦。漏斗机制：报告前 3 节（封面 / Top 3 角色 / 薪资）完全开放，后 4 节（Gap / 路径 / Action / 资源）遮罩，扫码加小助理微信拿统一激活码 `AIJOB-2026` 解锁。移动端优先（流量来自微信生态）。
 
@@ -22,8 +28,8 @@ docker compose up -d --build # Docker (port 3004:3000)
 
 ### 数据层
 
-- `src/data/tracks.ts` — 4 主线元数据（A AI PM / B AI 运营 / C AI 转型咨询 / D AIGC 创意）
-- `src/data/form-fields.ts` — 10 字段表单定义（5 必填 + 5 推荐）
+- `src/data/tracks.ts` — 4 主线元数据（A AI PM / B AI 运营 / C AI 转型咨询 / D AIGC 创意）。E 主线（留在原行业 + AI 增强）见 issue #17，待 agent-hunt#10 数据落地后引入
+- `src/data/form-fields.ts` — 10 字段表单定义（5 必填 + 5 推荐）；yearsExp 含应届分支（在读学生 / 应届无实习 / 应届有实习）
 - `src/data/free-resources.ts` — 按主线分的免费资源清单
 - `public/data/roles-domestic.json` + `skills.json` — agent-hunt v0.6 数据快照
 
@@ -31,28 +37,33 @@ docker compose up -d --build # Docker (port 3004:3000)
 
 - `src/lib/fetchAgentHunt.ts` — 客户端拉 agent-hunt JSON（远程优先，fallback 本地）
 - `src/lib/serverData.ts` — server 端读 `public/data/` JSON（OG 路由用）
-- `src/lib/matching.ts` — 用户技能 → 14 角色匹配算法。含稀疏角色置信度惩罚 `min(1, (req+pref)/5)`，避免 1-skill 小众角色被刷 100%
-- `src/lib/reportGen.ts` — UserInput + roles → 7 节报告 JSON。含 fallback 机制：当所有匹配为 0 时，把 targetTrack 锚点角色 hoist 到 Top 1，并设 `meta.isFallback`
-- `src/lib/encoding.ts` — base64url 编码用户输入，便于分享
-- `src/lib/track.ts` — 漏斗埋点（form_submit / report_view / mask_see / code_enter_*），初期 console + localStorage ring buffer，预留 window.plausible
+- `src/lib/matching.ts` — 用户技能 → 14 角色匹配算法。含稀疏角色置信度惩罚 `min(1, (req+pref)/5)`、`whyMatched` 推理链（hitRequired/hitPreferred/targetTrackBoost/educationPenalty/lowConfidence/industryFit），路线 B 时通过 `options.lockedRoleId` 仅算锁定角色
+- `src/lib/reportGen.ts` — UserInput + roles → 7 节报告 JSON。`generateReport` 路线 A 全量匹配 + Top 3 + 4 主线分布；`generateRouteBReport` 路线 B 仅锁定角色 + 跳过 Top 3。含 fallback 机制：路线 A 当所有匹配为 0 时把 targetTrack 锚点角色 hoist 到 Top 1，并设 `meta.isFallback`
+- `src/lib/audience.ts` — 受众类型推断（fresh-grad / social）。基于 yearsExp，驱动 ReportPaths/ReportActions 文案差异
+- `src/lib/encoding.ts` — base64url 编码用户输入。UserInput 含 `route?: "A" | "B"` + `targetRoleId?` 路线字段
+- `src/lib/track.ts` — 漏斗埋点（form_submit / route_b_submit / report_view / report_reject_top3_click / mask_see / code_enter_*），初期 console + localStorage ring buffer，预留 window.plausible
 - `src/lib/useragent.ts` — `isWeChat()` / `isMobile()` 检测（SSR-safe）
 - `src/lib/ogFont.ts` — OG 图字体加载。`public/fonts/noto-sans-sc-{400,700}.woff2` 本地优先，失败 fallback `fonts.googleapis.cn`
 
 ### UI 组件
 
-- `src/components/Report*.tsx` — 7 节报告组件（Cover / Roles / Salary / Gap / Paths / Actions + 第 7 节合并到 Actions）
+- `src/components/Report*.tsx` — 7 节报告组件（Cover / Roles / Salary / Gap / Paths / Actions + 第 7 节合并到 Actions）。Cover & Roles 按 `data.route` 切 A/B 渲染；Roles 显示 whyMatched 推理；Paths/Actions 按 audience 切应届/社招文案
 - `src/components/ReportFallbackNotice.tsx` — 0-match 兜底提示（黄色 banner，解释 required_skills 命中 0 的原因 + 推荐 target track keySkills）
 - `src/components/LockedSections.tsx` — 后 4 节软门槛。`useSyncExternalStore` 读 localStorage `aijobfit_unlocked`，激活码 `AIJOB-2026`（大小写不敏感，trimmed）
 - `src/components/AssistantQR.tsx` — 小助理微信 QR 组件，默认读 `public/qr-assistant.png`，env `NEXT_PUBLIC_ASSISTANT_QR_URL` 可覆盖
-- `src/components/DiagnosisForm.tsx` — 多步表单，含 form_submit 埋点
+- `src/components/DiagnosisForm.tsx` — 路线 A 多步表单，含 form_submit 埋点
+- `src/components/DiagnosisFormB.tsx` — 路线 B 多步表单（锁定行业 + 岗位 → 背景 + 技能 → 偏好），含 route_b_submit 埋点；用 `useSearchParams` 读 `?from=<hash>` 预填
+- `src/components/FormFieldRender.tsx` — 表单字段渲染 helper（路线 A/B 共用）
+- `src/components/TrackOverview.tsx` — 4 主线卡片组件（首页 + Step 2 折叠面板共用），数据驱动从 TRACKS iterate
 - `src/components/SharePoster.tsx` — 1080×1920 竖版 Canvas 海报（client），QR 指向首页引流
 
 ### 路由
 
-- `src/app/page.tsx` — 首页 Hero + 数据锚点 + 卖点
-- `src/app/diagnose/page.tsx` — 表单页
+- `src/app/page.tsx` — 首页 Hero + 双 CTA（路线 A / B） + 4 主线总览 + 数据锚点 + 卖点
+- `src/app/diagnose/page.tsx` — 路线 A 表单页
+- `src/app/diagnose-target/page.tsx` — 路线 B 表单页（Suspense 包 useSearchParams）
 - `src/app/result/[hash]/page.tsx` — server component，metadata 同时提供 1200×630 + 800×800 两套 og:image
-- `src/app/result/[hash]/ReportClient.tsx` — 客户端报告渲染。顶部栏：保存分享图、复制链接（微信 WebView 下降级为"点右上角 · 复制链接"提示）
+- `src/app/result/[hash]/ReportClient.tsx` — 客户端报告渲染。顶部栏：保存分享图、复制链接（微信 WebView 下降级为"点右上角 · 复制链接"提示）。路线 A 报告底部加"切到目标 Gap 诊断"CTA → `/diagnose-target?from=<hash>` 带预填
 - `src/app/api/og/route.tsx` — 站点级静态 OG（英文，不依赖字体）
 - `src/app/api/og/[hash]/route.tsx` — 动态 OG 1200×630（Top 1 角色 + 匹配度 + 薪资）
 - `src/app/api/og-square/route.tsx` — 站点级方形 OG（800×800，微信聊天卡片）
@@ -70,7 +81,9 @@ docker compose up -d --build # Docker (port 3004:3000)
 ## 产品已锁定的决策（不再重新讨论）
 
 - **本 app 永久免费，不做产品内付费**。商业化（1V1 / 社群 / 课程）在产品外独立运营
-- 4 主线定位保留 / 不承诺包就业 / 透明数据机制
+- **产品形态 = 双路线并行**：路线 A 定位诊断 + 路线 B 目标 Gap 诊断，互不替代
+- **受众 = 双一等受众**：社招用户 + 应届生 / 学生（含在读 / 应届无实习 / 应届有实习），表单分支 + 报告文案分应届/社招
+- 4 主线定位保留 / 不承诺包就业 / 透明数据机制（E 主线 5 主线扩展见 #17，待 agent-hunt#10 数据落地）
 - 报告免费推免费资源的边界：不为了导流付费课程而压低自学路径的真实评价
 - 遮罩组件不预留"将来替换为付费"的抽象；未来不会重启产品内付费
 
@@ -87,10 +100,15 @@ docker compose up -d --build # Docker (port 3004:3000)
 - **加微信漏斗**：前 3 节开放 / 后 4 节遮罩 / 激活码 AIJOB-2026（#7 #8）
 - **移动端适配**：375px 基线，全站断点重排（#6）
 - **微信生态**：方形 OG 800×800、WebView 复制链接降级、长按 QR 识别（#9 #5）
-- **漏斗埋点**：form_submit / report_view / mask_see / code_enter_{success,fail}（#10）
+- **漏斗埋点**：form_submit / route_b_submit / report_view / report_reject_top3_click / mask_see / code_enter_{success,fail}（#10 #15 #21）
 - **算法修复**：calcTrackScores 走全量、稀疏角色置信度惩罚、fallback 锚点 hoist、Gap priority 基线（#11）
 - **真 QR 替换**：`public/qr-assistant.png`（500×450，2026-04-28），生产端到端浏览器测试已通（#12）
 - **移动端 UI polish**：报告封面 `currentJob` wrap、Gap 行 mobile 堆叠（`flex-col sm:flex-row`）、QR size 150→180（rendered 130→160）、blur 容器 420→480
+- **报告可解释性**：每个推荐角色显示 whyMatched 推理链（命中骨架 + 加权折扣 + 行业匹配 + 0 命中诚实声明）（#18）
+- **路线 B 端到端**：`/diagnose-target` 锁定行业 + 岗位 → 仅算匹配率 + Gap，不展示 Top 3。Cover/Roles 按 route 切渲染（#15）
+- **报告兜底 CTA**：路线 A 报告底部"切到目标 Gap 诊断"，跳转预填用户已填字段（#21）
+- **主线分支透明化**：首页 + 表单 step 2 展示 4 主线 keySkills + targetUsers + JD 数 + 中位月薪（#20）
+- **应届生一等受众**：yearsExp 加在读学生 / 应届无实习 / 应届有实习分支；ReportPaths + ReportActions 按 audience 切应届/社招文案（#16）
 - **CI**：GitHub Actions lint + tsc + build
 - **运营 / 业务文档**：
   - [`docs/产品手册-运营版.md`](./docs/产品手册-运营版.md) — 话术 / FAQ / 异常处理
@@ -98,9 +116,15 @@ docker compose up -d --build # Docker (port 3004:3000)
   - [`docs/pdf/`](./docs/pdf/) — 两份 md 的 PDF 构建产物（直接发给业务方）
   - `scripts/build-docs-pdf.sh` — md → PDF 一键重建（pandoc + Chrome headless）
 
-## 剩余 open issue（非代码）
+## 剩余 open issue
 
+依赖 agent-hunt 数据：
+- **#16 应届生数据切片部分**：表单分支 + 文案差异已上，graduate-friendly 推荐结果差异化等 agent-hunt#11
+- **#17 第 5 主线 E**：CLAUDE.md 锁定决策已更新双路线 + 双受众；E 主线 TRACKS 数据 + 推荐逻辑等 agent-hunt#10
+- **#19 行业 × 岗位维度**：等 agent-hunt#9 二维切片数据
+
+非代码：
 - **#13**：测试 · 微信实机全链路（手机微信扫 QR → 加好友 → 拿激活码，不在代码里）
 - **#14**：数据 · 漏斗埋点观察期 + 门槛调优决策
 
-已关闭：#1 付费墙、#2 PDF（pivot 废弃）| #3 agent-hunt refetch（aijobfit 侧完工，跨仓 todo 迁移至 agent-hunt#7）| #4 部署（已上线）| #5-#11 见上文
+已关闭：#1 付费墙 · #2 PDF（pivot 废弃）· #3 agent-hunt refetch · #4 部署 · #5-#12 早期迭代 · #15 路线 B · #18 whyMatched · #20 主线透明化 · #21 报告兜底 CTA

--- a/src/components/ReportPaths.tsx
+++ b/src/components/ReportPaths.tsx
@@ -38,6 +38,7 @@ function ResourceItem({ r }: { r: Resource }) {
 export default function ReportPaths({ data }: { data: PathsData }) {
   const track = data.topTrack;
   const trackKey = track?.id || "A";
+  const isFreshGrad = data.audience === "fresh-grad";
 
   return (
     <section className="bg-white rounded-2xl shadow-sm border border-blue-100 p-5 sm:p-8">
@@ -49,10 +50,14 @@ export default function ReportPaths({ data }: { data: PathsData }) {
       {/* 路径 A：自学 */}
       <div className="border border-slate-200 rounded-xl p-4 sm:p-5 mb-4">
         <h3 className="text-lg font-bold text-slate-900 mb-1">
-          路径 A · 自学（免费 / 适合时间充裕 + 自驱力强）
+          {isFreshGrad
+            ? "路径 A · 自学（免费 / 应届校招前的黄金窗口）"
+            : "路径 A · 自学（免费 / 适合时间充裕 + 自驱力强）"}
         </h3>
         <p className="text-xs text-slate-500 mb-4">
-          每周 10h+ · 历史上完成过自学项目 · 经济敏感
+          {isFreshGrad
+            ? "在校时间充裕 · 不影响应届身份 · 适合做 portfolio 项目积累"
+            : "每周 10h+ · 历史上完成过自学项目 · 经济敏感"}
         </p>
 
         <div className="mb-4">
@@ -105,10 +110,14 @@ export default function ReportPaths({ data }: { data: PathsData }) {
       {/* 路径 B：3800 就业班 */}
       <div className="border border-blue-200 rounded-xl p-4 sm:p-5 mb-4 bg-blue-50/30">
         <h3 className="text-lg font-bold text-slate-900 mb-1">
-          路径 B · 3800 就业班（适合需要节奏感 + 教练 + 同伴）
+          {isFreshGrad
+            ? "路径 B · 3800 就业班（应届秋招 / 春招冲刺最佳节奏）"
+            : "路径 B · 3800 就业班（适合需要节奏感 + 教练 + 同伴）"}
         </h3>
         <p className="text-xs text-slate-500 mb-3">
-          12 周陪跑 · 同班分流 · 每月开 1 期 · 不打饥饿营销
+          {isFreshGrad
+            ? "12 周陪跑刚好衔接秋招 / 春招 · 同班分流 · 不打饥饿营销"
+            : "12 周陪跑 · 同班分流 · 每月开 1 期 · 不打饥饿营销"}
         </p>
 
         <div className="text-sm text-slate-700 space-y-1.5 mb-3">

--- a/src/data/form-fields.ts
+++ b/src/data/form-fields.ts
@@ -31,10 +31,18 @@ export const FORM_FIELDS: FormField[] = [
   },
   {
     id: "yearsExp",
-    label: "工作年限",
+    label: "工作年限 / 在校状态",
     type: "select",
     required: true,
-    options: ["应届", "1-3 年", "3-5 年", "5-10 年", "10+ 年"],
+    options: [
+      "在读学生",
+      "应届生（无实习）",
+      "应届生（有实习）",
+      "1-3 年",
+      "3-5 年",
+      "5-10 年",
+      "10+ 年",
+    ],
     step: 1,
   },
   {

--- a/src/lib/audience.ts
+++ b/src/lib/audience.ts
@@ -1,0 +1,10 @@
+// 受众类型推断：基于 yearsExp 字段判断用户是应届/学生还是社招用户。
+// 应届路径偏向校招/实习节奏；社招路径偏向项目/portfolio 增量。
+
+export type AudienceType = "fresh-grad" | "social";
+
+const FRESH_GRAD_VALUES = ["应届", "在读学生", "应届生（无实习）", "应届生（有实习）"];
+
+export function audienceTypeFromYears(yearsExp: string): AudienceType {
+  return FRESH_GRAD_VALUES.includes(yearsExp) ? "fresh-grad" : "social";
+}

--- a/src/lib/reportGen.ts
+++ b/src/lib/reportGen.ts
@@ -4,6 +4,7 @@ import { Role, Skill } from "./fetchAgentHunt";
 import { UserInput } from "./encoding";
 import { matchUserToRoles, RoleMatch } from "./matching";
 import { TRACKS, Track } from "@/data/tracks";
+import { AudienceType, audienceTypeFromYears } from "./audience";
 
 export interface CoverData {
   title: string;
@@ -48,6 +49,7 @@ export interface GapData {
 
 export interface PathsData {
   topTrack: Track | null;
+  audience: AudienceType;
 }
 
 export interface ActionsData {
@@ -183,6 +185,23 @@ function buildGap(top: RoleMatch | undefined): GapData {
 
 function buildActions(input: UserInput, topTrack: Track | null): ActionsData {
   const trackName = topTrack?.name || "你的目标主线";
+  const audience = audienceTypeFromYears(input.yearsExp);
+  if (audience === "fresh-grad") {
+    return {
+      d7: [
+        "用 Cursor / Claude Code 完成 1 个小自动化（写邮件脚本、整理课件、爬数据都行）",
+        "加入 1 个 AI 校招 / 实习社群（看准 / 牛客 / 即刻 AI Agent 玩家 / 任选）",
+      ],
+      d30: [
+        "完成 Datawhale 一期公益训练营（免费）",
+        "投出第一份 AI 实习 / 校招简历，跑 3-5 个真实面试拿反馈",
+      ],
+      d90: [
+        `1 段 AI 实习经验或 1 个能演示的 ${trackName} 项目，进入秋招 / 春招`,
+        "重新做一次本诊断报告，对比你的 Gap 缩小了多少",
+      ],
+    };
+  }
   return {
     d7: [
       "用 Cursor / Claude Code 完成你日常工作中的 1 个小自动化（哪怕只是写邮件脚本）",
@@ -275,7 +294,7 @@ export function generateReport(
     },
     salary: buildSalary(input, top),
     gap: buildGap(top),
-    paths: { topTrack },
+    paths: { topTrack, audience: audienceTypeFromYears(input.yearsExp) },
     actions: buildActions(input, topTrack),
     meta: {
       jdTotal: JD_TOTAL,
@@ -334,7 +353,7 @@ function generateRouteBReport(
     },
     salary: buildSalary(input, top),
     gap: buildGap(top),
-    paths: { topTrack: lockedTrack },
+    paths: { topTrack: lockedTrack, audience: audienceTypeFromYears(input.yearsExp) },
     actions: buildActions(input, lockedTrack),
     meta: {
       jdTotal: JD_TOTAL,


### PR DESCRIPTION
## Summary

实现两件事：

**1. #16 应届生作为一等受众（前端 + 文案部分）**

业务原话：

> "如果第一个问题是学生呢？应届生？就填学生是嘛？"
> "那如果没有实习过呢，能做选项嘛，好学校的去实习的才比较多。"

业务延伸观察："就业"标题本身比"跨行"更吸引应届生 → 我们的标题在主动招应届流量但产品没接住。

**2. #17 CLAUDE.md "已锁定决策" 更新（不阻塞部分）**

把 #15（已合）+ #16 实现的事实写进锁定决策 — 双路线 + 双一等受众。

注：#17 完整实现的"5 主线 E"还卡在 agent-hunt#10（AI 原生 vs 增强型岗位标签），所以 4 主线说法保留，仅更新双路线 / 双受众两条决策。

## Changes

**应届生：**
- `src/data/form-fields.ts` — yearsExp options：`应届` 单选项 → `在读学生 / 应届生（无实习）/ 应届生（有实习）` 三个明确分支；label 从 "工作年限" → "工作年限 / 在校状态"
- `src/lib/audience.ts` — 新文件，`audienceTypeFromYears(yearsExp)` 返回 `fresh-grad | social`，含 backward-compat alias（旧 URL 里的 "应届" 仍识别成 fresh-grad）
- `src/lib/reportGen.ts` — `buildActions` 按 audience 切 d7/d30/d90 文案；`PathsData` 加 `audience` 字段，路线 A/B 都填
- `src/components/ReportPaths.tsx` — 应届时 path A 副标题改"应届校招前的黄金窗口"、path B 改"应届秋招/春招冲刺最佳节奏"

**CLAUDE.md：**
- Overview 增加双路线 + 双一等受众段落
- 已锁定决策加：「产品形态 = 双路线并行」「受众 = 双一等受众」
- Architecture / 已交付 反映 #15 / #16 / #18 / #20 / #21
- 剩余 open issue 重新梳理（哪些等 agent-hunt / 哪些非代码）

## Test plan

- [x] **应届分支**：yearsExp=应届生（无实习）→ Path A 副标题"应届校招前的黄金窗口"、Path B 副标题"应届秋招/春招冲刺最佳节奏"、d7=校招社群、d30=投 AI 实习简历、d90=1 段实习+秋春招
- [x] **社招回归**：yearsExp=3-5 年 → 维持原 Path A "适合时间充裕 + 自驱力强" / d30 "Dify/Coze 搭 Agent"，应届专属文案完全不出现
- [x] **旧 URL 兼容**：旧 URL 里 yearsExp="应届" 字符串仍被 audienceTypeFromYears 识别为 fresh-grad
- [x] lint + tsc + build 全绿

## Acceptance criteria (from #16)

- [x] 表单能选"在读学生 / 应届有实习 / 应届无实习"
- [x] 应届分支推荐结果与社招分支显著不同（路径副标题 + 7/30/90 行动列表 6 处文案差异）
- [x] 报告路径节按应届/社招出两个版本
- [x] CLAUDE.md Overview 已更新受众章节

⚠️ **数据层差异化（推荐结果按 graduate-friendly 切片）等 LLM-X-Factorer/agent-hunt#11**。本 PR 完成的是表单分支 + 文案差异化，足以让应届流量看到针对性内容；推荐结果质量等数据上来后再调。

## Acceptance criteria (from #17, partial)

- [x] CLAUDE.md "已锁定决策" 加 "产品形态 = 双路线并行"
- [x] CLAUDE.md "已锁定决策" 加 "受众 = 双一等受众"
- [ ] CLAUDE.md "4 主线" → "5 主线" — **等 agent-hunt#10 落地后再切**

🤖 Generated with [Claude Code](https://claude.com/claude-code)