### PR TITLE
feat: route B share artifacts + bidirectional bottom CTAs + /diagnose prefill

### DIFF
--- a/src/app/api/og-square/[hash]/route.tsx
+++ b/src/app/api/og-square/[hash]/route.tsx
@@ -39,8 +39,13 @@ export async function GET(
     const report = generateReport(input, roles, skills, reportId);
 
     const top = report.cover.topRoles[0];
-    const topRole = top?.roleName || "—";
+    const isRouteB = report.cover.route === "B";
+    const topRole =
+      isRouteB && report.cover.lockedTarget?.industry
+        ? `${report.cover.lockedTarget.industry} · ${top?.roleName || "—"}`
+        : top?.roleName || "—";
     const topScore = top?.matchScore ?? 0;
+    const labelText = isRouteB ? "你的目标岗位" : "你最匹配的 AI 角色";
     const { p50 } = report.salary;
     const hasSalary = p50 > 0;
 
@@ -122,7 +127,7 @@ export async function GET(
                 marginBottom: 8,
               }}
             >
-              你最匹配的 AI 角色
+              {labelText}
             </div>
             <div
               style={{

--- a/src/app/api/og/[hash]/route.tsx
+++ b/src/app/api/og/[hash]/route.tsx
@@ -37,8 +37,13 @@ export async function GET(
     const report = generateReport(input, roles, skills, reportId);
 
     const top = report.cover.topRoles[0];
-    const topRole = top?.roleName || "—";
+    const isRouteB = report.cover.route === "B";
+    const topRole =
+      isRouteB && report.cover.lockedTarget?.industry
+        ? `${report.cover.lockedTarget.industry} · ${top?.roleName || "—"}`
+        : top?.roleName || "—";
     const topScore = top?.matchScore ?? 0;
+    const labelText = isRouteB ? "你的目标匹配度" : "Top 1 角色匹配";
     const { p25, p50, p75 } = report.salary;
     const hasSalary = p50 > 0;
 
@@ -124,7 +129,7 @@ export async function GET(
                 fontWeight: 400,
               }}
             >
-              Top 1 角色匹配
+              {labelText}
             </div>
             <div
               style={{

--- a/src/app/diagnose/page.tsx
+++ b/src/app/diagnose/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { Suspense } from "react";
 import DiagnosisForm from "@/components/DiagnosisForm";
 
 export default function DiagnosePage() {
@@ -18,7 +19,15 @@ export default function DiagnosePage() {
           5 个必填 + 5 个推荐字段，约 3 分钟。提交后立即生成报告，URL 可分享。
         </p>
       </div>
-      <DiagnosisForm />
+      <Suspense
+        fallback={
+          <div className="max-w-2xl mx-auto text-center text-sm text-slate-500 py-12">
+            正在加载表单…
+          </div>
+        }
+      >
+        <DiagnosisForm />
+      </Suspense>
     </main>
   );
 }

--- a/src/app/result/[hash]/ReportClient.tsx
+++ b/src/app/result/[hash]/ReportClient.tsx
@@ -167,6 +167,36 @@ export default function ReportClient({ hash }: { hash: string }) {
             </Link>
           </section>
         )}
+        {report.meta.route === "B" && (
+          <section className="bg-blue-50 border border-blue-200 rounded-2xl p-5 sm:p-8 text-center">
+            <h3 className="text-lg sm:text-xl font-bold text-slate-900 mb-2">
+              觉得这个目标不太对？
+            </h3>
+            <p className="text-sm text-slate-600 mb-5 max-w-xl mx-auto leading-relaxed">
+              你可以换个目标重新诊断，或者让系统基于你的技能推荐 Top 3 角色。已填字段都会带过去。
+            </p>
+            <div className="flex flex-col sm:flex-row gap-3 items-stretch sm:items-center justify-center">
+              <Link
+                href={`/diagnose-target?from=${encodeURIComponent(hash)}`}
+                onClick={() =>
+                  track("report_b_reselect_target_click", { report_id: report.meta.reportId })
+                }
+                className="inline-block bg-white border-2 border-blue-600 text-blue-700 hover:bg-blue-50 active:bg-blue-100 font-bold px-6 py-3 rounded-full transition-all"
+              >
+                重选目标 →
+              </Link>
+              <Link
+                href={`/diagnose?from=${encodeURIComponent(hash)}`}
+                onClick={() =>
+                  track("report_b_switch_to_a_click", { report_id: report.meta.reportId })
+                }
+                className="inline-block bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white font-bold px-6 py-3 rounded-full transition-all"
+              >
+                让系统推荐 Top 3 →
+              </Link>
+            </div>
+          </section>
+        )}
       </div>
 
       <footer className="border-t border-slate-200 px-4 py-6 text-center text-xs text-slate-500 bg-white">

--- a/src/components/DiagnosisForm.tsx
+++ b/src/components/DiagnosisForm.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { FORM_FIELDS, STEP_TITLES } from "@/data/form-fields";
-import { encodeInput, UserInput } from "@/lib/encoding";
+import { decodeInput, encodeInput, UserInput } from "@/lib/encoding";
 import { track } from "@/lib/track";
 import { FormFieldRender } from "@/components/FormFieldRender";
 
@@ -15,14 +15,38 @@ function isEmpty(v: unknown): boolean {
   return false;
 }
 
+function buildInitialState(fromHash: string | null): FormState {
+  const base: FormState = { skills: [], targetTrack: [], industry: [] };
+  if (!fromHash) return base;
+  try {
+    const prev = decodeInput(fromHash);
+    return {
+      ...base,
+      currentJob: prev.currentJob || "",
+      yearsExp: prev.yearsExp || "",
+      education: prev.education || "",
+      city: prev.city || "",
+      skills: prev.skills || [],
+      targetTrack: prev.targetTrack || [],
+      industry: prev.industry || [],
+      motivation: prev.motivation || "",
+      timeBudget: prev.timeBudget || "",
+      expectedSalary:
+        prev.expectedSalaryMin && prev.expectedSalaryMax
+          ? `${prev.expectedSalaryMin}-${prev.expectedSalaryMax}`
+          : "",
+    };
+  } catch {
+    return base;
+  }
+}
+
 export default function DiagnosisForm() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const fromHash = searchParams.get("from");
   const [step, setStep] = useState<1 | 2 | 3>(1);
-  const [state, setState] = useState<FormState>({
-    skills: [],
-    targetTrack: [],
-    industry: [],
-  });
+  const [state, setState] = useState<FormState>(() => buildInitialState(fromHash));
   const [customSkill, setCustomSkill] = useState("");
   const [error, setError] = useState<string | null>(null);
   const startedAtRef = useRef<number>(0);

--- a/src/components/SharePoster.tsx
+++ b/src/components/SharePoster.tsx
@@ -127,14 +127,20 @@ async function drawPoster(report: Report): Promise<string> {
   const top = cover.topRoles[0];
   const topRoleName = top?.roleName || "—";
   const topScore = top?.matchScore ?? 0;
+  const isRouteB = cover.route === "B";
+  const cardLabel = isRouteB ? "锁定目标 · 匹配度" : "Top 1 角色匹配";
+  const displayRoleName =
+    isRouteB && cover.lockedTarget?.industry
+      ? `${cover.lockedTarget.industry} · ${topRoleName}`
+      : topRoleName;
 
   ctx.fillStyle = "rgba(255,255,255,0.7)";
   ctx.font = "400 26px system-ui, -apple-system, sans-serif";
-  ctx.fillText("Top 1 角色匹配", PAD + 40, y + 60);
+  ctx.fillText(cardLabel, PAD + 40, y + 60);
 
   ctx.fillStyle = "#FFFFFF";
   ctx.font = "700 72px system-ui, -apple-system, sans-serif";
-  ctx.fillText(topRoleName, PAD + 40, y + 150);
+  ctx.fillText(displayRoleName, PAD + 40, y + 150);
 
   // 匹配度 pill
   ctx.font = "700 40px system-ui, -apple-system, sans-serif";
@@ -211,47 +217,49 @@ async function drawPoster(report: Report): Promise<string> {
     ctx.fillText("暂无足够数据", PAD, y + 40);
   }
 
-  // ===== 4 主线匹配条 =====
+  // ===== 4 主线匹配条（路线 A）/ 单角色已展示在大卡（路线 B 时跳过本节）=====
   y += 160;
-  ctx.fillStyle = TEXT_MUTED;
-  ctx.font = "400 26px system-ui, -apple-system, sans-serif";
-  ctx.fillText("4 主线匹配度", PAD, y);
-  y += 36;
-
-  const barAreaW = POSTER_W - PAD * 2;
-  const rowH = 64;
-  const barH = 14;
-  const sortedTracks = [...cover.trackScores].sort(
-    (a, b) => b.score - a.score,
-  );
-  sortedTracks.forEach((t, i) => {
-    const rowY = y + i * rowH;
-    ctx.fillStyle = TEXT_DARK;
-    ctx.font = "500 26px system-ui, -apple-system, sans-serif";
-    ctx.textAlign = "left";
-    ctx.fillText(`${t.track.id} · ${t.track.name}`, PAD, rowY + 10);
-
+  if (!isRouteB && cover.trackScores.length > 0) {
     ctx.fillStyle = TEXT_MUTED;
-    ctx.font = "500 24px system-ui, -apple-system, sans-serif";
-    ctx.textAlign = "right";
-    ctx.fillText(`${Math.round(t.score)}%`, POSTER_W - PAD, rowY + 10);
+    ctx.font = "400 26px system-ui, -apple-system, sans-serif";
+    ctx.fillText("4 主线匹配度", PAD, y);
+    y += 36;
 
-    // bar track
-    const barY = rowY + 24;
-    ctx.fillStyle = "#E2E8F0";
-    roundRect(ctx, PAD, barY, barAreaW, barH, barH / 2);
-    ctx.fill();
-    // bar fill
-    const fillW = Math.max(0, Math.min(1, t.score / 100)) * barAreaW;
-    if (fillW > 0) {
-      ctx.fillStyle = BRAND;
-      roundRect(ctx, PAD, barY, fillW, barH, barH / 2);
+    const barAreaW = POSTER_W - PAD * 2;
+    const rowH = 64;
+    const barH = 14;
+    const sortedTracks = [...cover.trackScores].sort(
+      (a, b) => b.score - a.score,
+    );
+    sortedTracks.forEach((t, i) => {
+      const rowY = y + i * rowH;
+      ctx.fillStyle = TEXT_DARK;
+      ctx.font = "500 26px system-ui, -apple-system, sans-serif";
+      ctx.textAlign = "left";
+      ctx.fillText(`${t.track.id} · ${t.track.name}`, PAD, rowY + 10);
+
+      ctx.fillStyle = TEXT_MUTED;
+      ctx.font = "500 24px system-ui, -apple-system, sans-serif";
+      ctx.textAlign = "right";
+      ctx.fillText(`${Math.round(t.score)}%`, POSTER_W - PAD, rowY + 10);
+
+      // bar track
+      const barY = rowY + 24;
+      ctx.fillStyle = "#E2E8F0";
+      roundRect(ctx, PAD, barY, barAreaW, barH, barH / 2);
       ctx.fill();
-    }
-  });
-  ctx.textAlign = "left";
+      // bar fill
+      const fillW = Math.max(0, Math.min(1, t.score / 100)) * barAreaW;
+      if (fillW > 0) {
+        ctx.fillStyle = BRAND;
+        roundRect(ctx, PAD, barY, fillW, barH, barH / 2);
+        ctx.fill();
+      }
+    });
+    ctx.textAlign = "left";
 
-  y += sortedTracks.length * rowH + 20;
+    y += sortedTracks.length * rowH + 20;
+  }
 
   // ===== 分割线 =====
   y += 20;


### PR DESCRIPTION
## Summary

把路线 B 的分享/兜底体验补齐 — 海报 + OG + 来回 CTA。

不直接 close 任何 issue（这些是 #15 上线后浮出来的 polish），但让路线 B 真正能像路线 A 一样**被分享 + 可逆切换**。

## Changes

### 路线 B 分享物适配
- `src/components/SharePoster.tsx`（1080×1920 海报）：路线 B 时大卡 label 由 "Top 1 角色匹配" 切到 "锁定目标 · 匹配度"，角色名前缀加 `industry · `，跳过空的 "4 主线匹配度" 节
- `src/app/api/og/[hash]/route.tsx`（1200×630 OG）：路线 B 时 label "你的目标匹配度"
- `src/app/api/og-square/[hash]/route.tsx`（800×800 微信卡）：路线 B 时 label "你的目标岗位"

### 路线 B 报告底部双 CTA
- `src/app/result/[hash]/ReportClient.tsx`：路线 B 报告底部 section "觉得这个目标不太对？"，两个并列按钮：
  - **重选目标** → `/diagnose-target?from=<hash>`（route B 同流程换目标）
  - **让系统推荐 Top 3** → `/diagnose?from=<hash>`（切回 route A）
- 埋点：`report_b_reselect_target_click` / `report_b_switch_to_a_click`

### /diagnose 也支持 ?from 预填
- `src/components/DiagnosisForm.tsx`：用 `useSearchParams` 读 `?from=<hash>`，base64url 解码后通过 `useState(() => buildInitialState(fromHash))` 初始化（mirror DiagnosisFormB 的实现，避开 React 19 set-state-in-effect 规则）
- `src/app/diagnose/page.tsx`：`<Suspense>` 包裹 DiagnosisForm（Next 16 要求 useSearchParams 客户端组件外有 Suspense 边界）

## Test plan

- [x] **路线 B 报告**：底部出现 "觉得这个目标不太对？" + 双按钮，href 分别指向 `/diagnose-target?from=` 和 `/diagnose?from=`
- [x] **跨路线预填**：`/diagnose?from=<route-B-hash>` 进入后 step 1 四个字段（currentJob / yearsExp / education / city）已自动填，targetTrack（路线 B 时为空数组）也带过来
- [x] **OG 双端点 200**：`/api/og/[B-hash]` 和 `/api/og-square/[B-hash]` 都返回 200（无 render 异常）
- [x] **路线 A 回归**：`/diagnose` 无 ?from 仍走空表单；路线 A 报告底部仍显示原 "切到目标 Gap 诊断" CTA
- [x] lint + tsc + build 全绿

## Why now

路线 B 刚 #15 上线，还没有真用户分享/兜底过。这两个补丁先于真实流量，避免：
- 路线 B 用户分享时海报渲染怪（"Top 1 角色匹配" 文案 + 4 主线空 section 是 bug）
- 路线 B 用户对锁定目标不满意时无出口（之前只能整个流程重走）

🤖 Generated with [Claude Code](https://claude.com/claude-code)