### PR TITLE
feat: cross-route hints + form B locked-target summary

### DIFF
--- a/src/app/diagnose-target/page.tsx
+++ b/src/app/diagnose-target/page.tsx
@@ -18,6 +18,15 @@ export default function DiagnoseTargetPage() {
         <p className="text-sm text-slate-500">
           已经有目标岗位 + 行业？选好后，我们围绕这个目标算匹配率 + 缺什么。
         </p>
+        <p className="mt-3 text-xs text-slate-500">
+          还不确定目标？
+          <Link
+            href="/diagnose"
+            className="ml-1 text-blue-600 hover:underline font-medium"
+          >
+            让系统帮你定位 →
+          </Link>
+        </p>
       </div>
       <Suspense
         fallback={

--- a/src/app/diagnose/page.tsx
+++ b/src/app/diagnose/page.tsx
@@ -18,6 +18,15 @@ export default function DiagnosePage() {
         <p className="text-sm text-slate-500">
           5 个必填 + 5 个推荐字段，约 3 分钟。提交后立即生成报告，URL 可分享。
         </p>
+        <p className="mt-3 text-xs text-slate-500">
+          已经有明确目标？
+          <Link
+            href="/diagnose-target"
+            className="ml-1 text-blue-600 hover:underline font-medium"
+          >
+            切到目标 Gap 诊断 →
+          </Link>
+        </p>
       </div>
       <Suspense
         fallback={

--- a/src/components/DiagnosisFormB.tsx
+++ b/src/components/DiagnosisFormB.tsx
@@ -37,6 +37,7 @@ function buildInitialState(fromHash: string | null): FormState {
       motivation: prev.motivation || "",
       timeBudget: prev.timeBudget || "",
       targetIndustry: (prev.industry && prev.industry[0]) || "",
+      targetRoleId: prev.targetRoleId || "",
       expectedSalary:
         prev.expectedSalaryMin && prev.expectedSalaryMax
           ? `${prev.expectedSalaryMin}-${prev.expectedSalaryMax}`
@@ -244,6 +245,21 @@ export default function DiagnosisFormB() {
             </div>
           </>
         )}
+
+        {step !== 1 && (() => {
+          const lockedRole = roles.find((r) => r.role_id === state.targetRoleId);
+          const industry = state.targetIndustry as string;
+          if (!lockedRole && !industry) return null;
+          return (
+            <div className="-mt-2 -mb-2 bg-blue-50 border border-blue-200 rounded-lg px-4 py-2.5 text-sm">
+              <span className="text-slate-500 mr-1.5">已锁目标：</span>
+              <span className="font-bold text-slate-900">
+                {industry && <>{industry} · </>}
+                {lockedRole?.role_name || "—"}
+              </span>
+            </div>
+          );
+        })()}
 
         {step !== 1 &&
           fieldsForStep.map((f) => (


### PR DESCRIPTION
## Summary

3 个小的 UX 补丁，让两条路线之间的切换更自然、表单 B 用户少迷失：

1. `/diagnose` 顶部加 hint "已经有明确目标？切到目标 Gap 诊断 →"
2. `/diagnose-target` 顶部对称加 hint "还不确定目标？让系统帮你定位 →"
3. DiagnosisFormB step 2/3 顶部加 "已锁目标：[行业] · [岗位]" banner
4. （顺手）`buildInitialState` 修复：之前从路线 B 报告 "重选目标" 跳回 form B 时，targetRoleId 没被还原，要求用户重新选岗位

## Test plan

- [x] `/diagnose` 顶部见到指向 `/diagnose-target` 的提示 link
- [x] `/diagnose-target?from=<route-B-hash>` step 1 自动选中 industry chip + role select；进 step 2 banner 显示 "已锁目标：互联网 · AI 产品经理"
- [x] lint + tsc + build 全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)