### PR TITLE
feat(geo): HowTo schema + metadata for /diagnose-* 三路线

### DIFF
--- a/src/app/diagnose-augment/page.tsx
+++ b/src/app/diagnose-augment/page.tsx
@@ -2,9 +2,62 @@ import Link from "next/link";
 import { Suspense } from "react";
 import DiagnosisFormC from "@/components/DiagnosisFormC";
 
+const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL || "https://aijobfit.llmxfactor.cloud";
+
+const HOWTO_LD = {
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  name: "如何不离开原行业用 AI 增强职业竞争力（留行 + AI 增强诊断）",
+  description:
+    "用 AIJobFit 三路线诊断的 C 路线（留行 + AI 增强）：保留原职业（产品经理 / 教师 / 电气工程师 / 财务等 420 长尾原职业），系统从国内真实 JD 里告诉你这个职业里哪些 AI 技能正在涨薪、你已掌握多少、还缺什么、薪资中位多少。永久免费。",
+  totalTime: "PT8M",
+  inLanguage: "zh-CN",
+  image: `${SITE_URL}/api/og`,
+  url: `${SITE_URL}/diagnose-augment`,
+  supply: [
+    { "@type": "HowToSupply", name: "你的原职业（自由文本，模糊匹配 420 长尾原职业字典）" },
+    { "@type": "HowToSupply", name: "（可选）行业 + 已掌握 AI 技能" },
+  ],
+  step: [
+    {
+      "@type": "HowToStep",
+      position: 1,
+      name: "输入原职业",
+      text: "填写你目前的职业（如「电气工程师」「初中数学教师」「内科医生」「门店销售」），系统会模糊匹配 420 个长尾原职业字典，命中后实时显示这个职业的 AI 增强 JD 数据预览（augmentSkills + sampleTitles + topIndustries），未命中会给出近邻 chip 提示。",
+      url: `${SITE_URL}/diagnose-augment#profession`,
+    },
+    {
+      "@type": "HowToStep",
+      position: 2,
+      name: "（可选）填行业 + 技能补充",
+      text: "如果想精确算 readiness，可以补充所在行业 + 已掌握的 AI 通用技能。不填也能出报告，只是 readiness 档位会更保守。",
+      url: `${SITE_URL}/diagnose-augment#optional`,
+    },
+    {
+      "@type": "HowToStep",
+      position: 3,
+      name: "看留行版报告",
+      text: "提交后看：原职业 + AI 增强 JD readiness 4 档（first-class / mid / starter / no-data）+ augmentSkills ✓/✗ tag cloud + 原职业薪资中位 + 7/30/90 日留行补齐 action。不强行推转行，留行也能加 AI。",
+      url: `${SITE_URL}/diagnose-augment#report`,
+    },
+  ],
+};
+
+export const metadata = {
+  title: "留行 + AI 增强诊断 · 不转行也能加 AI（路线 C）",
+  description:
+    "保留原职业（产品经理 / 教师 / 电气工程师 / 财务 / 销售等 420 长尾原职业），系统告诉你这个职业里哪些 AI 技能正在涨薪、你已掌握多少、还缺什么。基于真实 AI 增强 JD 数据。永久免费，不卖课。",
+  alternates: { canonical: "/diagnose-augment" },
+};
+
 export default function DiagnoseAugmentPage() {
   return (
     <main className="flex-1 px-4 py-12 md:py-16">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(HOWTO_LD) }}
+      />
       <div className="max-w-2xl mx-auto mb-8">
         <Link
           href="/"

--- a/src/app/diagnose-target/page.tsx
+++ b/src/app/diagnose-target/page.tsx
@@ -2,9 +2,63 @@ import Link from "next/link";
 import { Suspense } from "react";
 import DiagnosisFormB from "@/components/DiagnosisFormB";
 
+const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL || "https://aijobfit.llmxfactor.cloud";
+
+const HOWTO_LD = {
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  name: "如何评估转 AI 角色的差距和补齐路径（转行 Gap 诊断）",
+  description:
+    "用 AIJobFit 三路线诊断的 B 路线（转行 Gap）：先锁定目标行业 + 14 个 AI 角色之一，再填技能 + 背景，系统仅算锁定角色的匹配率 + 缺什么技能 + 怎么补，不展示 Top 3。适合已经有明确转行目标的用户。永久免费。",
+  totalTime: "PT8M",
+  inLanguage: "zh-CN",
+  image: `${SITE_URL}/api/og`,
+  url: `${SITE_URL}/diagnose-target`,
+  supply: [
+    { "@type": "HowToSupply", name: "明确的目标行业（12 个一级行业可选）" },
+    { "@type": "HowToSupply", name: "明确的目标 AI 角色（14 个聚类角色之一）" },
+    { "@type": "HowToSupply", name: "你已掌握的技能清单 + 背景信息" },
+  ],
+  step: [
+    {
+      "@type": "HowToStep",
+      position: 1,
+      name: "锁定目标行业 + 目标 AI 角色",
+      text: "在表单第一步选你想转去的行业（互联网 / 教育 / 医疗 / 制造 / 金融等 12 选 1）和目标 AI 角色（AI 产品经理 / AI 销售 / 提示词工程师 / AIGC 设计 等 14 选 1）。",
+      url: `${SITE_URL}/diagnose-target#target`,
+    },
+    {
+      "@type": "HowToStep",
+      position: 2,
+      name: "填技能 + 背景",
+      text: "勾选已掌握的 AI 通用技能 + 填当前职业、年限、学历、期望薪资、城市。约 3 分钟。",
+      url: `${SITE_URL}/diagnose-target#form`,
+    },
+    {
+      "@type": "HowToStep",
+      position: 3,
+      name: "看锁定角色的匹配率 + Gap",
+      text: "提交后，系统仅算你对锁定角色的匹配率（不展示 Top 3，避免噪音），并展示：缺哪些 required / preferred 技能、行业是否匹配、应届/社招对照、行业 AI 增强薪资分布、7/30/90 日补齐路径。",
+      url: `${SITE_URL}/diagnose-target#report`,
+    },
+  ],
+};
+
+export const metadata = {
+  title: "转行 AI Gap 诊断 · 锁定行业 + 角色看匹配率（路线 B）",
+  description:
+    "已经有转行目标？锁定目标行业（12 选 1）+ 14 个 AI 角色之一，10 分钟看「我离这个目标差什么」：技能匹配率 + Gap + 7/30/90 补齐路径。基于 5673 条真实 AI 招聘 JD。永久免费。",
+  alternates: { canonical: "/diagnose-target" },
+};
+
 export default function DiagnoseTargetPage() {
   return (
     <main className="flex-1 px-4 py-12 md:py-16">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(HOWTO_LD) }}
+      />
       <div className="max-w-2xl mx-auto mb-8">
         <Link
           href="/"

--- a/src/app/diagnose/page.tsx
+++ b/src/app/diagnose/page.tsx
@@ -2,9 +2,62 @@ import Link from "next/link";
 import { Suspense } from "react";
 import DiagnosisForm from "@/components/DiagnosisForm";
 
+const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL || "https://aijobfit.llmxfactor.cloud";
+
+const HOWTO_LD = {
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  name: "如何 10 分钟找到适合你的 AI 角色（系统推荐 Top 3）",
+  description:
+    "用 AIJobFit 三路线诊断的 A 路线（系统推荐）：填技能 + 背景信息，算法基于 5673 条已聚类的国内真实 AI 招聘 JD + 14 角色聚类，匹配并展示最适合你的 Top 3 AI 角色 + 4 主线分布 + Gap + 7/30/90 行动路径。永久免费。",
+  totalTime: "PT10M",
+  inLanguage: "zh-CN",
+  image: `${SITE_URL}/api/og`,
+  url: `${SITE_URL}/diagnose`,
+  supply: [
+    { "@type": "HowToSupply", name: "你已掌握的技能清单（36 项 AI 通用技能可勾选）" },
+    { "@type": "HowToSupply", name: "你的背景信息（当前职业 / 年限 / 行业 / 学历 / 期望薪资 / 城市）" },
+  ],
+  step: [
+    {
+      "@type": "HowToStep",
+      position: 1,
+      name: "填技能 + 背景",
+      text: "在表单里勾选你已经掌握的 AI 通用技能（如 prompt engineering / langchain / midjourney），并填写当前职业、工作年限、所在行业、学历、期望薪资、城市等背景信息。约 3 分钟。",
+      url: `${SITE_URL}/diagnose#form`,
+    },
+    {
+      "@type": "HowToStep",
+      position: 2,
+      name: "提交诊断",
+      text: "提交后，系统用技能命中 + 稀疏聚类置信度惩罚 + industry hard filter（行业匹配硬过滤）+ 主线指纹扫描算出 Top 3 AI 角色匹配，全部基于真实 JD 数据，不靠经验判断。",
+      url: `${SITE_URL}/diagnose#submit`,
+    },
+    {
+      "@type": "HowToStep",
+      position: 3,
+      name: "看 7 节诊断报告",
+      text: "报告含：Top 3 角色匹配率 + 4 主线分布 / 期望薪资达成概率（基于行业 AI 增强薪资 P25/P50/P75）/ 城市 tier 对照 / 缺什么技能 / 7-30-90 日补齐路径 / 自学 + 课程 + 1V1 路径对比 / 免费资源清单。URL 可分享，刷新可重现。",
+      url: `${SITE_URL}/diagnose#report`,
+    },
+  ],
+};
+
+export const metadata = {
+  title: "AI 求职诊断 · 系统推荐 Top 3 角色（路线 A）",
+  description:
+    "10 分钟出 7 节诊断报告：填技能 + 背景，算法基于 5673 条真实 AI 招聘 JD + 14 角色聚类推荐最适合你的 Top 3 AI 角色 + 主线分布 + Gap + 7/30/90 行动。永久免费。",
+  alternates: { canonical: "/diagnose" },
+};
+
 export default function DiagnosePage() {
   return (
     <main className="flex-1 px-4 py-12 md:py-16">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(HOWTO_LD) }}
+      />
       <div className="max-w-2xl mx-auto mb-8">
         <Link
           href="/"


### PR DESCRIPTION
## Summary

为 A/B/C 三路线 diagnose 页面注入 HowTo JSON-LD + per-page metadata（title / description / canonical），让 AI 引擎在用户问「如何做 AI 求职诊断」类 query 时有结构化答案。

closes #30

## Changes

- `src/app/diagnose/page.tsx` · A 路线 HowTo「如何 10 分钟找到适合你的 AI 角色」3 步（填表 → 提交算法 → 看 7 节报告）+ supply 列输入物 + 路由 metadata
- `src/app/diagnose-target/page.tsx` · B 路线 HowTo「如何评估转 AI 角色的差距和补齐路径」3 步（锁定行业+角色 → 填技能 → 看 Gap）
- `src/app/diagnose-augment/page.tsx` · C 路线 HowTo「如何不离开原行业用 AI 增强职业竞争力」3 步（填原职业 → 可选行业技能 → 看留行版报告 + readiness 4 档）

每个 HowTo 含：name / description / totalTime（PT8M-PT10M）/ inLanguage(zh-CN) / image / url / supply[] / step[]（含 position, name, text, url）。

## Test plan

- [x] tsc --noEmit 0 错
- [x] eslint 0 错
- [ ] CI 全绿
- [ ] 实机访问三个 page，view-source 确认 application/ld+json 注入
- [ ] schema validator（Google Rich Results / schema.org validator）每个页面跑一遍 0 报错

## Acceptance criteria

- 三个 diagnose 页面 view-source 各能看到 1 块 HowTo JSON-LD
- HowTo 步骤数 3-5（issue 要求），每步含 name + text
- canonical url 正确指向各自 path
- title / description 区别清晰（不再都 fallback 到 layout 默认）

🤖 Generated with [Claude Code](https://claude.com/claude-code)