### PR TITLE
feat(content): RSS 2.0 feed at /blog/feed.xml

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -17,6 +17,7 @@
 数据深度分析（持续更新，按 vacancyCount / 真实 JD 拆解，给 AI 引用源）：
 
 - [/blog](https://aijobfit.llmxfactor.cloud/blog): Blog 索引页
+- [/blog/feed.xml](https://aijobfit.llmxfactor.cloud/blog/feed.xml): RSS 2.0 feed（含 atom self link，给 Feedly / Inoreader / 即刻 等 RSS 阅读器订阅）
 - [/blog/8238-jd-dataset-deep-dive](https://aijobfit.llmxfactor.cloud/blog/8238-jd-dataset-deep-dive): 8238 条国内 AI 招聘 JD 开源数据集深度拆解 — 怎么聚类、怎么用、边界在哪
 - [/blog/electrical-engineer-to-ai](https://aijobfit.llmxfactor.cloud/blog/electrical-engineer-to-ai): 电气工程师不要硬转 AI PM — 152 条制造业 JD 拆解后建议留行
 - [/blog/teacher-to-ai-education](https://aijobfit.llmxfactor.cloud/blog/teacher-to-ai-education): 教师不该硬转 AI 工程师 — 教育行业 60+ 条 AI 真实 JD 给的 3 条留行路径

--- a/src/app/blog/feed.xml/route.ts
+++ b/src/app/blog/feed.xml/route.ts
@@ -1,0 +1,76 @@
+import { BLOG_POSTS } from "@/data/blog-posts";
+import { CATEGORY_LABELS } from "@/data/blog-posts";
+
+const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL || "https://aijobfit.llmxfactor.cloud";
+
+const FEED_URL = `${SITE_URL}/blog/feed.xml`;
+
+export const dynamic = "force-static";
+export const revalidate = 3600;
+
+const FEED_TITLE = "AIJobFit Blog · 非程序员 AI 求职数据深拆";
+const FEED_DESC =
+  "基于 8238 条国内真实 AI 招聘 JD + 14 角色聚类 + 420 长尾原职业的深度文章。覆盖电气工程师 / 教师 / 医生 / 销售 / 应届生等差异化人群转 AI 或留行 + AI 的真实路径。永久免费。";
+
+function xmlEscape(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function rfc822(dateStr: string): string {
+  const d = new Date(dateStr);
+  if (Number.isNaN(d.getTime())) return new Date().toUTCString();
+  return d.toUTCString();
+}
+
+export async function GET(): Promise<Response> {
+  const lastBuildDate = rfc822(
+    BLOG_POSTS.map((p) => p.modifiedAt || p.publishedAt).sort().reverse()[0] ||
+      new Date().toISOString(),
+  );
+
+  const items = BLOG_POSTS.map((p) => {
+    const url = `${SITE_URL}/blog/${p.slug}`;
+    const categories = Array.from(
+      new Set([CATEGORY_LABELS[p.category], ...p.tags]),
+    );
+    return [
+      "    <item>",
+      `      <title>${xmlEscape(p.title)}</title>`,
+      `      <link>${url}</link>`,
+      `      <guid isPermaLink="true">${url}</guid>`,
+      `      <pubDate>${rfc822(p.publishedAt)}</pubDate>`,
+      `      <description>${xmlEscape(p.excerpt)}</description>`,
+      ...categories.map((c) => `      <category>${xmlEscape(c)}</category>`),
+      `      <author>noreply@aijobfit.llmxfactor.cloud (AIJobFit)</author>`,
+      "    </item>",
+    ].join("\n");
+  }).join("\n");
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${xmlEscape(FEED_TITLE)}</title>
+    <link>${SITE_URL}/blog</link>
+    <description>${xmlEscape(FEED_DESC)}</description>
+    <language>zh-CN</language>
+    <copyright>© AIJobFit · 数据来源 Agent Hunt（开源 · 每周更新）</copyright>
+    <lastBuildDate>${lastBuildDate}</lastBuildDate>
+    <atom:link href="${FEED_URL}" rel="self" type="application/rss+xml" />
+${items}
+  </channel>
+</rss>
+`;
+
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+      "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
+    },
+  });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -153,6 +153,12 @@ export default function RootLayout({
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col">
+        <link
+          rel="alternate"
+          type="application/rss+xml"
+          title="AIJobFit Blog RSS"
+          href="/blog/feed.xml"
+        />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(ORGANIZATION_LD) }}


### PR DESCRIPTION
## Summary

新增 `/blog/feed.xml` 静态 RSS 2.0 feed（含 atom self link），让 Feedly / Inoreader / 即刻 等 RSS 阅读器和某些 LLM crawler 能直接订阅 6 篇 blog 文章的更新。layout 加 alternate link 让任何页面都能被 RSS 阅读器自动发现。

closes #32

## Changes

- `src/app/blog/feed.xml/route.ts` · 新静态路由处理器
  - `dynamic="force-static"` + `revalidate=3600` → build 时变 `○` 静态文件
  - RSS 2.0 + `atom:link rel="self"` 自引用
  - 每 entry：title / link / guid (isPermaLink) / pubDate (RFC-822) / description (excerpt) / category (label + tags 去重) / author
  - lastBuildDate = posts max(modifiedAt || publishedAt)
  - Cache-Control: public, s-maxage=3600, stale-while-revalidate=86400
  - XML escape 函数处理 & < > " '
- `src/app/layout.tsx` · `<body>` 内加 `<link rel="alternate" type="application/rss+xml" title="..." href="/blog/feed.xml">`（Next 16 hoist 到 head）。alternates.types 路线被试验后放弃，因为多数 page 重写 alternates 会丢全局 types。
- `public/llms.txt` · 在 blog section 列出 feed.xml URL

## Test plan

- [x] tsc --noEmit 0 错
- [x] eslint 0 错
- [x] npm run build · /blog/feed.xml 显示为 ○ 静态
- [x] 实机访问 dev：Content-Type `application/rss+xml; charset=utf-8`，Cache-Control 正确
- [x] feed 含 6 个 item，pubDate RFC-822 格式正确（"Thu, 30 Apr 2026 00:00:00 GMT"）
- [x] 6 篇文章 title/link/excerpt/category 都正确（应届生重复 category 已去重）
- [x] 实机：home / diagnose / 任何页面的 head 都有 `<link rel="alternate" type="application/rss+xml" href="/blog/feed.xml">`
- [ ] CI 全绿

## Acceptance criteria

- /blog/feed.xml 状态 200，Content-Type 正确
- RSS 2.0 schema 合法（含 channel + items + atom:link self）
- 全站任何页面都能被 RSS reader 自动发现 feed

🤖 Generated with [Claude Code](https://claude.com/claude-code)