### PR TITLE
feat(route-b): 0% 兜底显示 + 路径 B「点头就业班」文案

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          # 22.x：node:sqlite 内置模块（仍需 --experimental-sqlite 标志）
+          node-version: "22"
           cache: "npm"
 
       - run: npm ci
@@ -26,4 +27,6 @@ jobs:
         run: npx tsc --noEmit
 
       - name: Build
+        env:
+          NODE_OPTIONS: --experimental-sqlite
         run: npm run build

--- a/src/components/ReportCover.tsx
+++ b/src/components/ReportCover.tsx
@@ -1,4 +1,5 @@
 import { CoverData, AugmentTargetData } from "@/lib/reportGen";
+import AssistantQR from "./AssistantQR";
 
 export default function ReportCover({
   data,
@@ -173,27 +174,39 @@ export default function ReportCover({
         <div>
           <h3 className="text-sm font-bold text-slate-700 mb-3">你锁定的目标</h3>
           {data.lockedTarget && data.topRoles[0] ? (
-            <div className="bg-blue-50 border border-blue-200 rounded-xl p-5">
-              <p className="text-xs text-blue-600 font-mono mb-1">TARGET</p>
-              <div className="flex items-baseline justify-between flex-wrap gap-3">
-                <div>
-                  {data.lockedTarget.industry && (
-                    <p className="text-sm text-slate-600 mb-1">
-                      {data.lockedTarget.industry} 行业
+            <>
+              <div className="bg-blue-50 border border-blue-200 rounded-xl p-5">
+                <p className="text-xs text-blue-600 font-mono mb-1">TARGET</p>
+                <div className="flex items-baseline justify-between flex-wrap gap-3">
+                  <div>
+                    {data.lockedTarget.industry && (
+                      <p className="text-sm text-slate-600 mb-1">
+                        {data.lockedTarget.industry} 行业
+                      </p>
+                    )}
+                    <p className="text-xl sm:text-2xl font-black text-slate-900">
+                      {data.lockedTarget.roleName}
                     </p>
-                  )}
-                  <p className="text-xl sm:text-2xl font-black text-slate-900">
-                    {data.lockedTarget.roleName}
-                  </p>
-                </div>
-                <div className="text-right">
-                  <p className="text-4xl sm:text-5xl font-black text-blue-700">
-                    {data.topRoles[0].matchScore}%
-                  </p>
-                  <p className="text-xs text-slate-500 mt-1">综合匹配度</p>
+                  </div>
+                  <div className="text-right">
+                    <p className="text-4xl sm:text-5xl font-black text-blue-700">
+                      {data.topRoles[0].matchScore}%
+                    </p>
+                    <p className="text-xs text-slate-500 mt-1">综合匹配度</p>
+                  </div>
                 </div>
               </div>
-            </div>
+              {data.isLowMatch && (
+                <div className="mt-4 rounded-xl border border-amber-200 bg-amber-50 p-5">
+                  <p className="text-sm leading-relaxed text-slate-700">
+                    根据您的描述及市场数据，当前目标岗位的整体匹配度不高。建议您适当调整岗位方向后再尝试。您也可以扫描下方二维码，我们将根据您的具体情况，为您专项推荐更合适的岗位。
+                  </p>
+                  <div className="mt-4 flex justify-center">
+                    <AssistantQR size={160} caption="扫码加小助理，专项推荐岗位" />
+                  </div>
+                </div>
+              )}
+            </>
           ) : (
             <p className="text-sm text-slate-500">未锁定目标，请回到 /diagnose-target 重新选择</p>
           )}

--- a/src/components/ReportPaths.tsx
+++ b/src/components/ReportPaths.tsx
@@ -107,25 +107,31 @@ export default function ReportPaths({ data }: { data: PathsData }) {
         </p>
       </div>
 
-      {/* 路径 B：3800 就业班 */}
+      {/* 路径 B：点头就业班 */}
       <div className="border border-blue-200 rounded-xl p-4 sm:p-5 mb-4 bg-blue-50/30">
         <h3 className="text-lg font-bold text-slate-900 mb-1">
-          {isFreshGrad
-            ? "路径 B · 3800 就业班（应届秋招 / 春招冲刺最佳节奏）"
-            : "路径 B · 3800 就业班（适合需要节奏感 + 教练 + 同伴）"}
+          路径 B · 点头就业班（适合时间比较紧的人）
         </h3>
         <p className="text-xs text-slate-500 mb-3">
-          {isFreshGrad
-            ? "12 周陪跑刚好衔接秋招 / 春招 · 同班分流 · 不打饥饿营销"
-            : "12 周陪跑 · 同班分流 · 每月开 1 期 · 不打饥饿营销"}
+          三个月全程陪跑 · 项目集成 · 定向课程补差
         </p>
 
-        <div className="text-sm text-slate-700 space-y-1.5 mb-3">
-          <p>· 12 周陪跑（每周 1 次群直播 + 1 次 1V1 教练 + 班主任督学）</p>
-          <p>· 一个真实项目（按你主线方向定制）</p>
-          <p>· 完整 portfolio（简历改造 + Demo 视频 + 模拟面试录像）</p>
-          <p>· 加入校友社群</p>
+        <div className="text-sm text-slate-700 space-y-1 mb-3">
+          <p>从岗位所需能力倒推去设计的就业专项课程。</p>
+          <p>新手通识 → 基础算法 → 工程化核心 → 技术栈拓展</p>
+          <p className="font-medium text-slate-900">你缺什么，补什么。</p>
         </div>
+
+        <div className="text-sm text-slate-700 space-y-1.5 mb-3">
+          <p>· 34 专项课程录播 + 三个月直播课程补差</p>
+          <p>· 20+ 项目落地项目集成训练</p>
+          <p>· 封班强监督三个月全程陪跑</p>
+          <p>· 专业简历分析 + 定向模拟面试</p>
+        </div>
+
+        <p className="text-sm text-slate-700 mb-3">
+          把路铺好、把项目安排好、把监督做好，节省你的时间。
+        </p>
 
         <div className="text-xs text-slate-600 space-y-1 bg-white rounded p-3">
           <p>❌ 不承诺包就业</p>

--- a/src/lib/reportGen.ts
+++ b/src/lib/reportGen.ts
@@ -70,6 +70,8 @@ export interface CoverData {
   route: "A" | "B" | "C";
   // 路线 B：用户锁定的目标
   lockedTarget?: { industry?: string; roleName: string };
+  // 路线 B：原始 matchScore === 0 的兜底信号；UI 据此把 0% 显示成 ROUTE_B_FALLBACK_SCORE 并加调整方向 CTA
+  isLowMatch?: boolean;
   // 用户行业 → AI 增强 JD 切片，让封面带行业 context（"教育行业 59 条 AI 增强 JD"）
   industryContext?: {
     industryCN: string;
@@ -224,6 +226,10 @@ export interface Report {
 // JD 总数与角色总数现在从 narrative-stats.json runtime 读，远程不可达时回退到
 // 「数据源最低保证」（agent-hunt v0.7 时已经 5673 labeled / 8238 raw）。
 const JD_TOTAL_FALLBACK = 5673;
+
+// 路线 B 锁定目标 0% 兜底：原始 matchScore===0 时展示 5%，避免「0%」视觉冲击让用户直接离开；
+// 同时通过 cover.isLowMatch 信号在 UI 上补一条「建议调整方向 + 小助理 QR」CTA。
+const ROUTE_B_FALLBACK_SCORE = 5;
 
 function calcTrackScores(matches: RoleMatch[]): { track: Track; score: number }[] {
   // 用 TRANSITION_TRACKS 而不是 TRACKS：E 主线（留行）roleIds=[] 永远 score=0，
@@ -739,6 +745,14 @@ function generateRouteBReport(
   const freshComparison = buildFreshComparison(audience, gradEntry);
   const baseSalary = buildSalary(input, top, industrySalary, rolesByCity);
 
+  // 0% 显示兜底：matchScore 真实为 0 时展示 ROUTE_B_FALLBACK_SCORE，避免视觉冲击让用户直接离开。
+  // 但保留 whyMatched.zeroHit 等内部信号原状，给 reasoning 文案做诚实归因。
+  const isLowMatch = !!top && top.matchScore === 0;
+  const displayedScore = top ? (isLowMatch ? ROUTE_B_FALLBACK_SCORE : top.matchScore) : 0;
+  const displayedMatches = top
+    ? [{ ...top, matchScore: displayedScore }, ...matches.slice(1)]
+    : matches;
+
   return {
     cover: {
       title: top
@@ -750,7 +764,7 @@ function generateRouteBReport(
       city: input.city,
       trackScores: [],
       topRoles: top
-        ? [{ roleName: top.roleName, matchScore: top.matchScore }]
+        ? [{ roleName: top.roleName, matchScore: displayedScore }]
         : [],
       reportId,
       generatedAt,
@@ -758,12 +772,13 @@ function generateRouteBReport(
       lockedTarget: top
         ? { industry: lockedIndustry, roleName: top.roleName }
         : undefined,
+      isLowMatch,
       industryContext: buildIndustryContext(input, industrySalary),
       gradContext,
       trackFingerprints: buildTrackFingerprints(input),
     },
     roles: {
-      topMatches: matches,
+      topMatches: displayedMatches,
       totalRoles: rolesTotal,
       totalJDs: jdTotal,
       route: "B",


### PR DESCRIPTION
## Summary

业务方反馈两条调整：

- **Route B 锁定目标 0% 兜底**：当锁定目标算出 matchScore===0 时，显示数字 floor 到 **5%**，并在卡片下方加描述 + 小助理 QR：「根据您的描述及市场数据……您也可以扫描下方二维码，我们将根据您的具体情况，为您专项推荐更合适的岗位。」  
  实现层在 `generateRouteBReport` 内统一 floor（cover + roles section 同步），并新增 `cover.isLowMatch` 信号让 UI 渲染兜底 CTA；whyMatched.zeroHit 等内部归因信号保持原状不动。
- **路径 B 课程文案重写**：去掉「3800 就业班」标签，改成「**路径 B · 点头就业班（适合时间比较紧的人）**」，副标题「三个月全程陪跑 · 项目集成 · 定向课程补差」+ 4 条新 bullet。同时去掉 fresh-grad / social 文案分支（新文案普适）。

## Test plan

- [x] 构造零命中 Route B URL（电气工程师 + 教育行业 + 锁定 product_manager） → Section 1「你锁定的目标」显示 5% + amber 兜底文案 + 小助理 QR
- [x] 同一 URL 的 Section 2「你的目标匹配度」也显示 5%（一致性）
- [x] 构造有命中 Route B URL（产品经理 + 互联网 + 锁定 product_manager） → 显示真实 30%，**无**兜底文案
- [x] Section 5「3 种学习路径」路径 B 显示新文案（点头就业班 + 4 bullet + 结尾鼓励语）
- [x] 应届/社招用户文案统一（路径 B 取消 isFreshGrad 分支）
- [x] `npm run lint` / `npx tsc --noEmit` / `npm run build` 全绿
- [x] `npx tsx scripts/verify-acceptance.ts` 9 case 仍跑通

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)